### PR TITLE
added GTSAM and test support for equidistant model

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,12 @@ add_subdirectory(src/imu-frontend)
 ### Add source code for visualizer.
 add_subdirectory(include/kimera-vio/visualizer)
 add_subdirectory(src/visualizer)
+### Add source code for camera distortion models
+add_subdirectory(include/kimera-vio/distortion_models)
+add_subdirectory(src/distortion_models)
+### Add source code for gtsam distortion extensions
+add_subdirectory(include/kimera-vio/gtsam_distortion)
+add_subdirectory(src/gtsam_distortion)
 
 target_link_libraries(kimera_vio
   PRIVATE

--- a/include/kimera-vio/distortion_models/CMakeLists.txt
+++ b/include/kimera-vio/distortion_models/CMakeLists.txt
@@ -1,0 +1,7 @@
+### Add source code for gtsam distortion models
+target_sources(kimera_vio PRIVATE
+  "${CMAKE_CURRENT_LIST_DIR}/DistortionModel.h"
+  "${CMAKE_CURRENT_LIST_DIR}/RadTan4.h"
+  "${CMAKE_CURRENT_LIST_DIR}/RadTan8.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Equidistant4.h"
+)

--- a/include/kimera-vio/distortion_models/DistortionModel.h
+++ b/include/kimera-vio/distortion_models/DistortionModel.h
@@ -1,0 +1,76 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   DistortionModel.h
+ * @brief  base class for distortion (camera) models
+ * @author Bernd Pfrommer
+ */
+
+#ifndef INCLUDE_KIMERA_VIO_DISTORTION_MODELS_DISTORTIONMODEL_H_
+#define INCLUDE_KIMERA_VIO_DISTORTION_MODELS_DISTORTIONMODEL_H_
+
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Pose3.h>
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace VIO {
+/*
+ * base class for distortion models (radtan, equidistant etc)
+ */
+class DistortionModel {
+ public:
+  virtual ~DistortionModel() {}
+  typedef std::array<double, 4> Intrinsics;
+  // ----- methods to be implemented by the derived classes ----
+
+  virtual gtsam::Point2 uncalibrate(const gtsam::Point2& p) const = 0;
+
+  virtual gtsam::Point2 project(const gtsam::Pose3& pose,
+                                const gtsam::Point3& p) const = 0;
+
+  virtual bool equals(
+      const std::shared_ptr<const DistortionModel>& dm) const = 0;
+
+  virtual void print() const = 0;
+
+  virtual bool test(const double* intr, const double* dist) const = 0;
+
+  virtual double fx() const = 0;
+  virtual double fy() const = 0;
+  virtual double px() const = 0;
+  virtual double py() const = 0;
+  virtual double skew() const = 0;
+
+  // ------------ static methods ------------------
+
+  // factory method for distortion models
+  static std::shared_ptr<DistortionModel> make(
+      const std::string& name,
+      const Intrinsics& intrinsics,  // kx, ky, cu, cv
+      const std::vector<double>& dist_coeffs);
+
+  // factory method for pinhole camera without distortion
+  static std::shared_ptr<DistortionModel> make_pinhole(double fx,
+                                                       double fy,
+                                                       double cu,
+                                                       double cv);
+
+  // check if it is a valid model
+  static bool is_valid(const std::string& name, int num_dist_coeff = 4);
+};
+
+// define shared pointers
+typedef std::shared_ptr<DistortionModel> DistortionModelPtr;
+typedef std::shared_ptr<const DistortionModel> DistortionModelConstPtr;
+
+}  // namespace VIO
+
+#endif  // INCLUDE_KIMERA_VIO_DISTORTION_MODELS_DISTORTIONMODEL_H_

--- a/include/kimera-vio/distortion_models/Equidistant4.h
+++ b/include/kimera-vio/distortion_models/Equidistant4.h
@@ -1,0 +1,51 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   Equidistant4.h
+ * @brief  implements 4-coefficient equidistant (fisheye model)
+ * @author Bernd Pfrommer
+ */
+
+#ifndef INCLUDE_KIMERA_VIO_DISTORTION_MODELS_EQUIDISTANT4_H_
+#define INCLUDE_KIMERA_VIO_DISTORTION_MODELS_EQUIDISTANT4_H_
+
+#include "kimera-vio/distortion_models/DistortionModel.h"
+#include "kimera-vio/gtsam_distortion/Cal3FS2.h"
+
+#include <array>
+#include <memory>
+#include <vector>
+
+namespace VIO {
+class Equidistant4 : public DistortionModel {
+ public:
+  Equidistant4(const Intrinsics& intrinsics,
+               const std::vector<double>& dist_coeffs);
+  // method inherited from DistortionModel base class
+  gtsam::Point2 uncalibrate(const gtsam::Point2& p) const override;
+  bool equals(const DistortionModelConstPtr& dm) const override;
+  void print() const override;
+  bool test(const double* intr, const double* dist) const override;
+  gtsam::Point2 project(const gtsam::Pose3& pose,
+                        const gtsam::Point3& p) const override;
+  double fx() const override { return (model_.fx()); }
+  double fy() const override { return (model_.fy()); }
+  double px() const override { return (model_.px()); }
+  double py() const override { return (model_.py()); }
+  double skew() const override { return (0.0); }
+
+ private:
+  Cal3FS2 model_;
+};
+
+// pointers
+typedef std::shared_ptr<Equidistant4> Equidistant4Ptr;
+typedef std::shared_ptr<const Equidistant4> Equidistant4ConstPtr;
+}  // namespace VIO
+
+#endif  // INCLUDE_KIMERA_VIO_DISTORTION_MODELS_EQUIDISTANT4_H_

--- a/include/kimera-vio/distortion_models/RadTan4.h
+++ b/include/kimera-vio/distortion_models/RadTan4.h
@@ -1,0 +1,48 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   RadTan4.h
+ * @brief  implements original gtsam 4-coefficient radtan model
+ * @author Bernd Pfrommer
+ */
+
+#ifndef INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN4_H_
+#define INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN4_H_
+
+#include <gtsam/geometry/Cal3DS2.h>
+#include "kimera-vio/distortion_models/DistortionModel.h"
+
+#include <memory>
+#include <vector>
+
+namespace VIO {
+class RadTan4 : public DistortionModel {
+ public:
+  RadTan4(const Intrinsics& intrinsics, const std::vector<double>& dist_coeffs);
+  // method inherited from DistortionModel base class
+  gtsam::Point2 uncalibrate(const gtsam::Point2& p) const override;
+  bool equals(const DistortionModelConstPtr& dm) const override;
+  void print() const override;
+  bool test(const double* intr, const double* dist) const override;
+  gtsam::Point2 project(const gtsam::Pose3& pose,
+                        const gtsam::Point3& p) const override;
+  double fx() const override { return (model_.fx()); }
+  double fy() const override { return (model_.fy()); }
+  double px() const override { return (model_.px()); }
+  double py() const override { return (model_.py()); }
+  double skew() const override { return (model_.skew()); }
+
+ private:
+  gtsam::Cal3DS2 model_;
+};
+
+// pointers
+typedef std::shared_ptr<RadTan4> RadTan4Ptr;
+typedef std::shared_ptr<const RadTan4> RadTan4ConstPtr;
+}  // namespace VIO
+#endif  // INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN4_H_

--- a/include/kimera-vio/distortion_models/RadTan8.h
+++ b/include/kimera-vio/distortion_models/RadTan8.h
@@ -1,0 +1,47 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   RadTan8.h
+ * @brief  implements radtan model with p1, p2, k1...k6
+ * @author Bernd Pfrommer
+ */
+
+#ifndef INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN8_H_
+#define INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN8_H_
+
+#include <memory>
+#include <vector>
+#include "kimera-vio/distortion_models/DistortionModel.h"
+#include "kimera-vio/gtsam_distortion/Cal3DS3.h"
+
+namespace VIO {
+class RadTan8 : public DistortionModel {
+ public:
+  RadTan8(const Intrinsics& intrinsics, const std::vector<double>& dist_coeffs);
+  // method inherited from DistortionModel base class
+  gtsam::Point2 uncalibrate(const gtsam::Point2& p) const override;
+  bool equals(const DistortionModelConstPtr& dm) const override;
+  void print() const override;
+  bool test(const double* intr, const double* dist) const override;
+  gtsam::Point2 project(const gtsam::Pose3& pose,
+                        const gtsam::Point3& p) const override;
+  double fx() const override { return (model_.fx()); }
+  double fy() const override { return (model_.fy()); }
+  double px() const override { return (model_.px()); }
+  double py() const override { return (model_.py()); }
+  double skew() const override { return (0.0); }
+
+ private:
+  Cal3DS3 model_;
+};
+
+// pointers
+typedef std::shared_ptr<RadTan8> RadTan8Ptr;
+typedef std::shared_ptr<const RadTan8> RadTan8ConstPtr;
+}  // namespace VIO
+#endif  //  INCLUDE_KIMERA_VIO_DISTORTION_MODELS_RADTAN8_H_

--- a/include/kimera-vio/gtsam_distortion/CMakeLists.txt
+++ b/include/kimera-vio/gtsam_distortion/CMakeLists.txt
@@ -1,0 +1,5 @@
+### Add source code for gtsam distortion models
+target_sources(kimera_vio PRIVATE
+  "${CMAKE_CURRENT_LIST_DIR}/Cal3DS3.h"
+  "${CMAKE_CURRENT_LIST_DIR}/Cal3FS2.h"
+)

--- a/include/kimera-vio/gtsam_distortion/Cal3DS3.h
+++ b/include/kimera-vio/gtsam_distortion/Cal3DS3.h
@@ -1,0 +1,219 @@
+/* -*-c++-*--------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Bernd Pfrommer, based on code by
+ * Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Cal3DS3.h
+ * @brief Calibration of a camera with radtan p1,p2, k1...k6 distortion model
+ * @date November 15th, 2018
+ * @author bernd.pfrommer@gmail.com
+ */
+
+#ifndef INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3DS3_H_
+#define INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3DS3_H_
+
+#include <gtsam/geometry/Point2.h>
+#include <string>
+
+/**
+ * @brief Calibration of a camera with fisheye (radtan) radial distortion
+ * @addtogroup geometry
+ * \nosubgrouping
+ *
+ * Uses standard OpenCV radtan distortion model [aka plumb_bob]
+ *
+ * K = [ fx 0 u0 ; 0 fy v0 ; 0 0 1 ]
+ * rr = x^2 + y^2
+ * theta = atan(rr)
+ * f_rad = (1 + k_[0] * r^2 + k_[1] * r^4 + k_[2] * r^6)/
+ *         (1 + k_[3] * r^2 + k_[4] * r^4 + k_[5] * r^6)/
+ * x' = x * f_rad + 2*p_1*x*y           +   p_2(r^2 + 2*x^2)
+ * y' = y * f_rad +   p_1*(r^2 + 2y^2)  + 2*p_2*x*y
+ * y' = theta_d/r * y
+ * p  = K * p'
+ */
+class Cal3DS3 {
+ public:
+  enum { dimension = 12 };
+  enum { num_coeff = 6 };
+
+ protected:
+  double fx_, fy_, u0_, v0_;  // focal length,  and principal point
+  double p1_, p2_,
+      k_[num_coeff];  // radial distortion coefficients of radtan model
+
+ public:
+  /// @name Standard Constructors
+  /// @{
+
+  /// Default Constructor with only unit focal length
+  Cal3DS3() : fx_(1), fy_(1), u0_(0), v0_(0), p1_(0), p2_(0) {
+    for (int i = 0; i < num_coeff; i++) {
+      k_[i] = 0;
+    }
+  }
+
+  Cal3DS3(double fx,
+          double fy,
+          double u0,
+          double v0,
+          double p1,
+          double p2,
+          const double* k)
+      : fx_(fx), fy_(fy), u0_(u0), v0_(v0), p1_(p1), p2_(p2) {
+    for (int i = 0; i < num_coeff; i++) {
+      k_[i] = k[i];
+    }
+  }
+
+  virtual ~Cal3DS3() {}
+
+  /// @}
+  /// @name Advanced Constructors
+  /// @{
+
+  explicit Cal3DS3(const gtsam::Vector& v);
+
+  /// @}
+  /// @name Testable
+  /// @{
+
+  /// print with optional string
+  virtual void print(const std::string& s = "") const;
+
+  /// assert equality up to a tolerance
+  bool equals(const Cal3DS3& K, double tol = 10e-9) const;
+
+  /// @}
+  /// @name Standard Interface
+  /// @{
+
+  /// focal length x
+  inline double fx() const { return fx_; }
+
+  /// focal length x
+  inline double fy() const { return fy_; }
+
+  /// image center in x
+  inline double px() const { return u0_; }
+
+  /// image center in y
+  inline double py() const { return v0_; }
+
+  /// distortion p1
+  inline double p1() const { return p1_; }
+
+  /// image center in y
+  inline double p2() const { return p2_; }
+
+  /// distortion coefficients
+  inline double k1() const { return k_[0]; }
+  inline double k2() const { return k_[1]; }
+  inline double k3() const { return k_[2]; }
+  inline double k4() const { return k_[3]; }
+  inline double k5() const { return k_[4]; }
+  inline double k6() const { return k_[5]; }
+
+  /// return calibration matrix -- not really applicable
+  gtsam::Matrix3 K() const;
+
+  /// return distortion parameter vector
+  gtsam::Vector6 k() const {
+    gtsam::Vector6 v;
+    for (int i = 0; i < 6; i++) {
+      v(i) = k_[i];
+    }
+    return (v);
+  }
+
+  /// Return all parameters as a vector
+  Eigen::Matrix<double, 12, 1> vector() const;
+
+  /// @}
+  /// @name Manifold
+  /// @{
+
+  /// Given delta vector, update calibration
+  Cal3DS3 retract(const gtsam::Vector& d) const;
+
+  /// Given a different calibration, calculate update to obtain it
+  gtsam::Vector localCoordinates(const Cal3DS3& T2) const;
+
+  /// Return dimensions of calibration manifold object
+  virtual size_t dim() const { return dimension; }
+
+  /**
+   * convert intrinsic coordinates xy to (distorted) image coordinates uv
+   * @param p point in intrinsic coordinates
+   * @param Dcal optional 2*12 Jacobian wrpt Cal3DS3 parameters
+   * @param Dp optional 2*2 Jacobian wrpt intrinsic coordinates
+   * @return point in (distorted) image coordinates
+   */
+  gtsam::Point2 uncalibrate(
+      const gtsam::Point2& p,
+      gtsam::OptionalJacobian<2, 12> Dcal = boost::none,
+      gtsam::OptionalJacobian<2, 2> Dp = boost::none) const;
+
+  /// Convert (distorted) image coordinates uv to intrinsic coordinates xy
+  gtsam::Point2 calibrate(const gtsam::Point2& p,
+                          const double tol = 1e-5) const;
+
+  /// Derivative of uncalibrate wrpt intrinsic coordinates
+  gtsam::Matrix2 D2d_intrinsic(const gtsam::Point2& p) const;
+
+  /// Derivative of uncalibrate wrpt the calibration parameters
+  Eigen::Matrix<double, 2, 12> D2d_calibration(const gtsam::Point2& p) const;
+
+  /// @}
+  /// @name Clone
+  /// @{
+
+  /// @return a deep copy of this object
+  virtual boost::shared_ptr<Cal3DS3> clone() const {
+    return boost::shared_ptr<Cal3DS3>(new Cal3DS3(*this));
+  }
+
+  /// @}
+
+ private:
+  gtsam::Point2 uncalibrateNoIntrinsics(const gtsam::Point2& p) const;
+  /// @name Advanced Interface
+  /// @{
+
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar,  // NOLINT
+                 const unsigned int /*version*/) {
+    ar& BOOST_SERIALIZATION_NVP(fx_);
+    ar& BOOST_SERIALIZATION_NVP(fy_);
+    ar& BOOST_SERIALIZATION_NVP(u0_);
+    ar& BOOST_SERIALIZATION_NVP(v0_);
+    ar& BOOST_SERIALIZATION_NVP(p1_);
+    ar& BOOST_SERIALIZATION_NVP(p2_);
+    ar& BOOST_SERIALIZATION_NVP(k_[0]);
+    ar& BOOST_SERIALIZATION_NVP(k_[1]);
+    ar& BOOST_SERIALIZATION_NVP(k_[2]);
+    ar& BOOST_SERIALIZATION_NVP(k_[3]);
+    ar& BOOST_SERIALIZATION_NVP(k_[4]);
+    ar& BOOST_SERIALIZATION_NVP(k_[5]);
+  }
+
+  /// @}
+};
+// This is really ugly, injecting stuff into gtsam's namespace!
+namespace gtsam {
+template <>
+struct traits<Cal3DS3> : public gtsam::internal::Manifold<Cal3DS3> {};
+template <>
+struct traits<const Cal3DS3> : public gtsam::internal::Manifold<Cal3DS3> {};
+}  // namespace gtsam
+
+#endif  // INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3DS3_H_

--- a/include/kimera-vio/gtsam_distortion/Cal3FS2.h
+++ b/include/kimera-vio/gtsam_distortion/Cal3FS2.h
@@ -1,0 +1,201 @@
+/* -*-c++-*--------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Bernd Pfrommer, based on code by
+ * Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Cal3FS2.h
+ * @brief Calibration of a camera with equidistant (fisheye) distortion model
+ * @date July 1st, 2018
+ * @author bernd.pfrommer@gmail.com
+ */
+#ifndef INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3FS2_H_
+#define INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3FS2_H_
+
+#include <gtsam/geometry/Point2.h>
+#include <string>
+
+/**
+ * @brief Calibration of a camera with fisheye (radtan) radial distortion
+ * @addtogroup geometry
+ * \nosubgrouping
+ *
+ * Uses same distortionmodel as OpenCV fisheye calibration
+ * https://docs.opencv.org/trunk/db/d58/group__calib3d__fisheye.html
+ * but does not allow for skew
+ *
+ * K = [ fx 0 u0 ; 0 fy v0 ; 0 0 1 ]
+ * rr = x^2 + y^2
+ * theta = atan(rr)
+ * theta_d = theta*(1 + k1 * theta^2 + k2 * theta^4 + k3 * theta^6 + k4 *
+ * theta^8) x' = theta_d/r * x y' = theta_d/r * y p  = K * p'
+ */
+class Cal3FS2 {
+ protected:
+  double fx_, fy_, u0_, v0_;  // focal length,  and principal point
+  double k1_, k2_, k3_, k4_;  // radial distortion coefficients of radtan model
+
+ public:
+  enum { dimension = 8 };
+
+  /// @name Standard Constructors
+  /// @{
+
+  /// Default Constructor with only unit focal length
+  Cal3FS2() : fx_(1), fy_(1), u0_(0), v0_(0), k1_(0), k2_(0), k3_(0), k4_(0) {}
+
+  Cal3FS2(double fx,
+          double fy,
+          double u0,
+          double v0,
+          double k1,
+          double k2,
+          double k3,
+          double k4)
+      : fx_(fx),
+        fy_(fy),
+        u0_(u0),
+        v0_(v0),
+        k1_(k1),
+        k2_(k2),
+        k3_(k3),
+        k4_(k4) {}
+
+  virtual ~Cal3FS2() {}
+
+  /// @}
+  /// @name Advanced Constructors
+  /// @{
+
+  explicit Cal3FS2(const gtsam::Vector& v);
+
+  /// @}
+  /// @name Testable
+  /// @{
+
+  /// print with optional string
+  virtual void print(const std::string& s = "") const;
+
+  /// assert equality up to a tolerance
+  bool equals(const Cal3FS2& K, double tol = 10e-9) const;
+
+  /// @}
+  /// @name Standard Interface
+  /// @{
+
+  /// focal length x
+  inline double fx() const { return fx_; }
+
+  /// focal length x
+  inline double fy() const { return fy_; }
+
+  /// image center in x
+  inline double px() const { return u0_; }
+
+  /// image center in y
+  inline double py() const { return v0_; }
+
+  /// First distortion coefficient
+  inline double k1() const { return k1_; }
+
+  /// Second distortion coefficient
+  inline double k2() const { return k2_; }
+
+  /// Third distortion coefficient
+  inline double k3() const { return k3_; }
+
+  /// Fourth distortion coefficient
+  inline double k4() const { return k4_; }
+
+  /// return calibration matrix -- not really applicable
+  gtsam::Matrix3 K() const;
+
+  /// return distortion parameter vector
+  gtsam::Vector4 k() const { return gtsam::Vector4(k1_, k2_, k3_, k4_); }
+
+  /// Return all parameters as a vector
+  gtsam::Vector8 vector() const;
+
+  /// @}
+  /// @name Manifold
+  /// @{
+
+  /// Given delta vector, update calibration
+  Cal3FS2 retract(const gtsam::Vector& d) const;
+
+  /// Given a different calibration, calculate update to obtain it
+  gtsam::Vector localCoordinates(const Cal3FS2& T2) const;
+
+  /// Return dimensions of calibration manifold object
+  virtual size_t dim() const { return dimension; }
+
+  /**
+   * convert intrinsic coordinates xy to (distorted) image coordinates uv
+   * @param p point in intrinsic coordinates
+   * @param Dcal optional 2*8 Jacobian wrpt Cal3FS2 parameters
+   * @param Dp optional 2*2 Jacobian wrpt intrinsic coordinates
+   * @return point in (distorted) image coordinates
+   */
+  gtsam::Point2 uncalibrate(
+      const gtsam::Point2& p,
+      gtsam::OptionalJacobian<2, 8> Dcal = boost::none,
+      gtsam::OptionalJacobian<2, 2> Dp = boost::none) const;
+
+  /// Convert (distorted) image coordinates uv to intrinsic coordinates xy
+  gtsam::Point2 calibrate(const gtsam::Point2& p,
+                          const double tol = 1e-5) const;
+
+  /// Derivative of uncalibrate wrpt intrinsic coordinates
+  gtsam::Matrix2 D2d_intrinsic(const gtsam::Point2& p) const;
+
+  /// Derivative of uncalibrate wrpt the calibration parameters
+  gtsam::Matrix28 D2d_calibration(const gtsam::Point2& p) const;
+
+  /// @}
+  /// @name Clone
+  /// @{
+
+  /// @return a deep copy of this object
+  virtual boost::shared_ptr<Cal3FS2> clone() const {
+    return boost::shared_ptr<Cal3FS2>(new Cal3FS2(*this));
+  }
+
+  /// @}
+
+ private:
+  gtsam::Point2 uncalibrateNoIntrinsics(const gtsam::Point2& p) const;
+  /// @name Advanced Interface
+  /// @{
+
+  /** Serialization function */
+  friend class boost::serialization::access;
+  template <class Archive>
+  void serialize(Archive& ar,  // NOLINT
+                 const unsigned int /*version*/) {
+    ar& BOOST_SERIALIZATION_NVP(fx_);
+    ar& BOOST_SERIALIZATION_NVP(fy_);
+    ar& BOOST_SERIALIZATION_NVP(u0_);
+    ar& BOOST_SERIALIZATION_NVP(v0_);
+    ar& BOOST_SERIALIZATION_NVP(k1_);
+    ar& BOOST_SERIALIZATION_NVP(k2_);
+    ar& BOOST_SERIALIZATION_NVP(k3_);
+    ar& BOOST_SERIALIZATION_NVP(k4_);
+  }
+
+  /// @}
+};
+// This is really ugly, injecting stuff into gtsam's namespace!
+namespace gtsam {
+template <>
+struct traits<Cal3FS2> : public gtsam::internal::Manifold<Cal3FS2> {};
+template <>
+struct traits<const Cal3FS2> : public gtsam::internal::Manifold<Cal3FS2> {};
+}  // namespace gtsam
+
+#endif  // INCLUDE_KIMERA_VIO_GTSAM_DISTORTION_CAL3FS2_H_

--- a/src/distortion_models/CMakeLists.txt
+++ b/src/distortion_models/CMakeLists.txt
@@ -1,0 +1,9 @@
+### Add source code for distortion models
+target_sources(kimera_vio
+  PRIVATE
+  "${CMAKE_CURRENT_LIST_DIR}/DistortionModel.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/RadTan4.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/RadTan8.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/Equidistant4.cpp"
+)
+

--- a/src/distortion_models/DistortionModel.cpp
+++ b/src/distortion_models/DistortionModel.cpp
@@ -1,0 +1,85 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   DistortionModel.cpp
+ * @author Bernd Pfrommer
+ */
+
+#include "kimera-vio/distortion_models/DistortionModel.h"
+#include "kimera-vio/distortion_models/Equidistant4.h"
+#include "kimera-vio/distortion_models/RadTan4.h"
+#include "kimera-vio/distortion_models/RadTan8.h"
+
+#include <glog/logging.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace VIO {
+// check if it is a valid model
+bool DistortionModel::is_valid(const std::string& name, int num_dist_coeff) {
+  if (name == "radtan" || name == "radial-tangential" || name == "plumb-bob" ||
+      name == "plumb_bob") {
+    if (num_dist_coeff == 4 || num_dist_coeff == 8) {
+      return (true);
+    } else {
+      LOG(ERROR) << "distortion model " << name
+                 << " invalid num coeff: " << num_dist_coeff << std::endl;
+    }
+  } else if (name == "equidistant" || name == "equdist") {
+    if (num_dist_coeff == 4) {
+      return (true);
+    } else {
+      LOG(ERROR) << "distortion model " << name
+                 << " invalid num coeff: " << num_dist_coeff << std::endl;
+    }
+  } else {
+    LOG(ERROR) << " invalid distortion model " << name << std::endl;
+  }
+  return (false);
+}
+
+// factory method for creating pinhole model
+// with only px and py
+DistortionModelPtr DistortionModel::make_pinhole(double fx,
+                                                 double fy,
+                                                 double cu,
+                                                 double cv) {
+  std::vector<double> dist_coeffs = {0.0, 0.0, 0.0, 0.0};
+  Intrinsics intrinsics = {fx, fy, cu, cv};
+  return (std::shared_ptr<RadTan4>(new RadTan4(intrinsics, dist_coeffs)));
+}
+
+// factory method for creating distortion models
+DistortionModelPtr DistortionModel::make(
+    const std::string& name,       // radtan, equidistant etc...
+    const Intrinsics& intrinsics,  // kx, ky, cu, cv
+    const std::vector<double>& dist_coeffs) {
+  if (name == "radtan" || name == "radial-tangential" || name == "plumb-bob" ||
+      name == "plumb_bob") {
+    switch (dist_coeffs.size()) {
+      case 4:
+        return (std::shared_ptr<RadTan4>(new RadTan4(intrinsics, dist_coeffs)));
+      case 8:
+        return (std::shared_ptr<RadTan8>(new RadTan8(intrinsics, dist_coeffs)));
+      default:
+        throw std::runtime_error("radtan: only 4 or 8 dist coeff supported");
+    }
+  } else if (name == "equidistant" || name == "equidist") {
+    if (dist_coeffs.size() != 4) {
+      throw std::runtime_error("equidistant: only 4 dist coeff supported");
+      return (std::shared_ptr<Equidistant4>());
+    } else {
+      return (std::shared_ptr<Equidistant4>(
+          new Equidistant4(intrinsics, dist_coeffs)));
+    }
+  }
+  throw std::runtime_error("invalid distortion model");
+}
+}  // namespace VIO

--- a/src/distortion_models/Equidistant4.cpp
+++ b/src/distortion_models/Equidistant4.cpp
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   Equidistant4.cpp
+ * @author Bernd Pfrommer
+ */
+
+#include "kimera-vio/distortion_models/Equidistant4.h"
+
+#include <gtsam/geometry/PinholeCamera.h>
+#include <vector>
+
+namespace VIO {
+Equidistant4::Equidistant4(const Intrinsics& intrinsics,
+                           const std::vector<double>& distortion) {
+  model_ = Cal3FS2(intrinsics[0],   // fx
+                   intrinsics[1],   // fy
+                   intrinsics[2],   // u0 (px)
+                   intrinsics[3],   // v0 (py)
+                   distortion[0],   // k1
+                   distortion[1],   // k2
+                   distortion[2],   // k3
+                   distortion[3]);  // k4
+}
+
+gtsam::Point2 Equidistant4::uncalibrate(const gtsam::Point2& p) const {
+  return (model_.uncalibrate(p));
+}
+
+bool Equidistant4::equals(const DistortionModelConstPtr& dm) const {
+  Equidistant4ConstPtr eqm = std::dynamic_pointer_cast<const Equidistant4>(dm);
+  if (!eqm) {
+    return (false);
+  }
+  return model_.equals(eqm->model_);
+}
+
+void Equidistant4::print() const { model_.print(); }
+
+bool Equidistant4::test(const double* intr, const double* dist) const {
+  return (intr[0] == model_.fx() && intr[1] == model_.fy() &&
+          intr[2] == model_.px() && intr[3] == model_.py() &&
+          dist[0] == model_.k1() && dist[1] == model_.k2() &&
+          dist[2] == model_.k3() && dist[3] == model_.k4());
+}
+
+gtsam::Point2 Equidistant4::project(const gtsam::Pose3& pose,
+                                    const gtsam::Point3& p) const {
+  gtsam::PinholeCamera<Cal3FS2> cam(pose, model_);
+  return cam.project(p);
+}
+
+}  // namespace VIO

--- a/src/distortion_models/RadTan4.cpp
+++ b/src/distortion_models/RadTan4.cpp
@@ -1,0 +1,59 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   RadTan4.cpp
+ * @author Bernd Pfrommer
+ */
+
+#include "kimera-vio/distortion_models/RadTan4.h"
+
+#include <gtsam/geometry/PinholeCamera.h>
+#include <vector>
+
+namespace VIO {
+RadTan4::RadTan4(const Intrinsics& intrinsics,
+                 const std::vector<double>& distortion) {
+  model_ = gtsam::Cal3DS2(intrinsics[0],   // fx
+                          intrinsics[1],   // fy
+                          0.0,             // skew
+                          intrinsics[2],   // u0
+                          intrinsics[3],   // v0
+                          distortion[0],   // k1
+                          distortion[1],   // k2
+                          distortion[2],   // p1
+                          distortion[3]);  // p2
+}
+gtsam::Point2 RadTan4::uncalibrate(const gtsam::Point2& p) const {
+  return (model_.uncalibrate(p));
+}
+
+bool RadTan4::equals(const DistortionModelConstPtr& dm) const {
+  RadTan4ConstPtr rtm = std::dynamic_pointer_cast<const RadTan4>(dm);
+  if (!rtm) {
+    return (false);
+  }
+  return model_.equals(rtm->model_);
+}
+
+void RadTan4::print() const { model_.print(); }
+
+bool RadTan4::test(const double* intr, const double* dist) const {
+  return (intr[0] == model_.fx() && intr[1] == model_.fy() &&
+          intr[2] == model_.px() && intr[3] == model_.py() &&
+          dist[0] == model_.k1() && dist[1] == model_.k2() &&
+          dist[2] == model_.p1() && dist[3] == model_.p2());
+}
+
+gtsam::Point2 RadTan4::project(const gtsam::Pose3& pose,
+                               const gtsam::Point3& p) const {
+  gtsam::PinholeCamera<gtsam::Cal3DS2> cam(pose, model_);
+  return cam.project(p);
+}
+
+}  // namespace VIO

--- a/src/distortion_models/RadTan8.cpp
+++ b/src/distortion_models/RadTan8.cpp
@@ -1,0 +1,71 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   RadTan8.cpp
+ * @author Bernd Pfrommer
+ */
+
+#include "kimera-vio/distortion_models/RadTan8.h"
+#include <gtsam/geometry/PinholeCamera.h>
+#include <vector>
+
+namespace VIO {
+RadTan8::RadTan8(const Intrinsics& intrinsics,
+                 const std::vector<double>& distortion) {
+  // assume distortion parameters are specified as
+  // k1, k2, p1, p2, k3, k4, k5, k6
+  // (opencv convention)
+  std::vector<double> k;
+  k.push_back(distortion[0]);  // k1
+  k.push_back(distortion[1]);  // k2
+  // [2] and [3] are p1 and p2.
+  // now add the remaining k3 - k6's to
+  for (size_t i = 4; i < distortion.size(); i++) {
+    k.push_back(distortion[i]);
+  }
+  while (k.size() < 6) {
+    k.push_back(0);  // fill unspecified k's with 0
+  }
+  model_ = Cal3DS3(intrinsics[0],  // fx
+                   intrinsics[1],  // fy
+                   intrinsics[2],  // u0
+                   intrinsics[3],  // v0
+                   distortion[2],  // p1
+                   distortion[3],  // p2
+                   &k[0]);         // k1 .. k6
+}
+
+gtsam::Point2 RadTan8::uncalibrate(const gtsam::Point2& p) const {
+  return (model_.uncalibrate(p));
+}
+
+bool RadTan8::equals(const DistortionModelConstPtr& dm) const {
+  RadTan8ConstPtr rtm = std::dynamic_pointer_cast<const RadTan8>(dm);
+  if (!rtm) {
+    return (false);
+  }
+  return model_.equals(rtm->model_);
+}
+
+void RadTan8::print() const { model_.print(); }
+
+bool RadTan8::test(const double* intr, const double* dist) const {
+  return (intr[0] == model_.fx() && intr[1] == model_.fy() &&
+          intr[2] == model_.px() && intr[3] == model_.py() &&
+          dist[0] == model_.k1() && dist[1] == model_.k2() &&
+          dist[2] == model_.p1() && dist[3] == model_.p2());
+}
+
+gtsam::Point2 RadTan8::project(const gtsam::Pose3& pose,
+                               const gtsam::Point3& p) const {
+  gtsam::PinholeCamera<Cal3DS3> cam(pose, model_);
+  return cam.project(p);
+}
+
+}  // namespace VIO

--- a/src/frontend/FeatureSelector.cpp
+++ b/src/frontend/FeatureSelector.cpp
@@ -17,8 +17,8 @@
  * @author Luca Carlone
  */
 
-#include <boost/filesystem.hpp> // to create folders
 #include <glog/logging.h>
+#include <boost/filesystem.hpp>  // to create folders
 
 #include "kimera-vio/frontend/FeatureSelector.h"
 #include "kimera-vio/imu-frontend/ImuFrontEndParams.h"
@@ -127,7 +127,8 @@ void FeatureSelector::print() const {
 /* ------------------------------------------------------------------------ */
 // Multiply hessian in hessian factor ptr by nonnegative double
 void FeatureSelector::MultiplyHessianInPlace(
-    gtsam::HessianFactor::shared_ptr Deltaj, const double c) {
+    gtsam::HessianFactor::shared_ptr Deltaj,
+    const double c) {
   if (c < 0)
     throw std::runtime_error(
         "MultiplyHessianInPlace: cannot multiply by negative number");
@@ -211,8 +212,11 @@ FeatureSelector::featureSelectionLinearModel(
     std::cout << "featureSelectionLinearModel: createDeltas" << std::endl;
   }
   std::vector<gtsam::HessianFactor::shared_ptr> Deltas =
-      createDeltas(availableVersors, availableCornersDistances,
-                   featureSelectionData, left_cameras, right_cameras);
+      createDeltas(availableVersors,
+                   availableCornersDistances,
+                   featureSelectionData,
+                   left_cameras,
+                   right_cameras);
 
 #ifdef FEATURE_SELECTOR_DEBUG_COUT
   std::cout << "createDeltas time: "
@@ -260,8 +264,8 @@ FeatureSelector::featureSelectionLinearModel(
   for (auto ind : selectedIndices)
     selectedCorners.push_back(availableCorners.at(ind));
 
-  return std::make_tuple(selectedCorners, selectedIndices,
-                         selectedMarginalGains);
+  return std::make_tuple(
+      selectedCorners, selectedIndices, selectedMarginalGains);
 }
 
 /* ------------------------------------------------------------------------ */
@@ -603,7 +607,8 @@ boost::tuple<int, double, gtsam::Vector> FeatureSelector::SmallestEigsSpectra(
   Spectra::DenseSymMatProd<double> op(M);
 
   // Construct eigen solver object, requesting the largest three eigenvalues
-  Spectra::SymEigsSolver<double, Spectra::SMALLEST_MAGN,
+  Spectra::SymEigsSolver<double,
+                         Spectra::SMALLEST_MAGN,
                          Spectra::DenseSymMatProd<double>>
       eigs(&op, 1, round(M.cols() / 2));  //
 
@@ -634,7 +639,8 @@ FeatureSelector::SmallestEigsSpectraShift(const gtsam::Matrix& M) {
   // Construct matrix operation object using the wrapper class DenseGenMatProd
   Spectra::DenseSymShiftSolve<double> op(M);
 
-  Spectra::SymEigsShiftSolver<double, Spectra::LARGEST_MAGN,
+  Spectra::SymEigsShiftSolver<double,
+                              Spectra::LARGEST_MAGN,
                               Spectra::DenseSymShiftSolve<double>>
       eigs(&op, 1, round(M.cols() / 2), 0.0);
   eigs.init();
@@ -790,7 +796,8 @@ gtsam::JacobianFactor FeatureSelector::createPrior(
 /* ------------------------------------------------------------------------ */
 std::pair<gtsam::Matrix, gtsam::Matrix>
 FeatureSelector::createMatricesLinearImuFactor(
-    const StampedPose& poseStamped_i, const StampedPose& poseStamped_j) const {
+    const StampedPose& poseStamped_i,
+    const StampedPose& poseStamped_j) const {
   double Deltaij = poseStamped_j.timestampInSec -
                    poseStamped_i.timestampInSec;  // clearly in seconds
 
@@ -923,10 +930,14 @@ gtsam::GaussianFactorGraph FeatureSelector::createOmegaBarImuAndPrior(
 // Models measurement std and max distance 2) does not mode outliers, since we
 // "predict" ground truth measurements
 gtsam::HessianFactor::shared_ptr FeatureSelector::createLinearVisionFactor(
-    const gtsam::Point3& pworld_l, const Cameras& left_cameras,
-    const Cameras& right_cameras, double& debugFETime, double& debugSVDTime,
+    const gtsam::Point3& pworld_l,
+    const Cameras& left_cameras,
+    const Cameras& right_cameras,
+    double& debugFETime,
+    double& debugSVDTime,
     double& debugSchurTime,  // debug
-    const int keypointLife, bool hasRightPixel) const {
+    const int keypointLife,
+    bool hasRightPixel) const {
   // compute track lenght, depending on horizon and keypointLife
   size_t nrKeyframesInHorizon =
       std::min(left_cameras.size(), size_t(keypointLife));
@@ -1031,7 +1042,8 @@ gtsam::HessianFactor::shared_ptr FeatureSelector::createLinearVisionFactor(
 /* ------------------------------------------------------------------------ */
 gtsam::GaussianFactorGraph::shared_ptr FeatureSelector::createOmegaBar(
     const FeatureSelectorData& featureSelectionData,
-    const Cameras& left_cameras, const Cameras& right_cameras) const {
+    const Cameras& left_cameras,
+    const Cameras& right_cameras) const {
   // 1) add imu factors
 
 #ifdef FEATURE_SELECTOR_DEBUG_COUT
@@ -1069,9 +1081,14 @@ gtsam::GaussianFactorGraph::shared_ptr FeatureSelector::createOmegaBar(
         left_cameras.at(0).pose() *
         p_l_camL0;  // overload for tranform_from (converts to global frame)
     // add to graph
-    gtsam::HessianFactor::shared_ptr H_l = createLinearVisionFactor(
-        pworld_l, left_cameras, right_cameras, debugFETime, debugSVDTime,
-        debugSchurTime, featureSelectionData.keypointLife.at(l));
+    gtsam::HessianFactor::shared_ptr H_l =
+        createLinearVisionFactor(pworld_l,
+                                 left_cameras,
+                                 right_cameras,
+                                 debugFETime,
+                                 debugSVDTime,
+                                 debugSchurTime,
+                                 featureSelectionData.keypointLife.at(l));
     if (!H_l->empty())  // if not empty
       OmegaBar.push_back(H_l);
   }
@@ -1113,7 +1130,8 @@ std::vector<gtsam::HessianFactor::shared_ptr> FeatureSelector::createDeltas(
     const std::vector<gtsam::Vector3>& availableVersors,
     const std::vector<double>& availableCornersDistances,
     const FeatureSelectorData& featureSelectionData,
-    const Cameras& left_cameras, const Cameras& right_cameras) const {
+    const Cameras& left_cameras,
+    const Cameras& right_cameras) const {
   // sanity check:
   if (availableVersors.size() != availableCornersDistances.size())
     throw std::runtime_error("createDeltas: distance vector size mismatch");
@@ -1161,10 +1179,14 @@ std::vector<gtsam::HessianFactor::shared_ptr> FeatureSelector::createDeltas(
     double debugFETime = 0;
     double debugSVDTime = 0;
     double debugSchurTime = 0;
-    Deltas.push_back(createLinearVisionFactor(
-        pworld_l, left_cameras, right_cameras, debugFETime, debugSVDTime,
-        debugSchurTime, 1e9,  // infinite life
-        hasRightPixel));
+    Deltas.push_back(createLinearVisionFactor(pworld_l,
+                                              left_cameras,
+                                              right_cameras,
+                                              debugFETime,
+                                              debugSVDTime,
+                                              debugSchurTime,
+                                              1e9,  // infinite life
+                                              hasRightPixel));
   }
   return Deltas;
 }
@@ -1173,7 +1195,9 @@ std::vector<gtsam::HessianFactor::shared_ptr> FeatureSelector::createDeltas(
 // defined in terms of angle and maxDistance). If so returns a versor
 // corresponding to the direction to the point
 boost::optional<gtsam::Unit3> FeatureSelector::GetVersorIfInFOV(
-    const Camera& cam, const gtsam::Point3& pworld, const double& maxDistance) {
+    const Camera& cam,
+    const gtsam::Point3& pworld,
+    const double& maxDistance) {
   // check if a point p (expressed in global frame) falls in the FOV of the
   // camera cam, in which case the function returns a unit3 corresponding to the
   // direction at which p is observed
@@ -1205,7 +1229,9 @@ boost::optional<gtsam::Unit3> FeatureSelector::GetVersorIfInFOV(
  * Fixed size version
  */
 gtsam::SymmetricBlockMatrix FeatureSelector::SchurComplement(
-    const FBlocks& Fs, const gtsam::Matrix& E, const gtsam::Matrix3& P,
+    const FBlocks& Fs,
+    const gtsam::Matrix& E,
+    const gtsam::Matrix3& P,
     const gtsam::Vector& b) {
   // a single point is observed in m cameras
   size_t m = Fs.size();
@@ -1228,7 +1254,8 @@ gtsam::SymmetricBlockMatrix FeatureSelector::SchurComplement(
 
     // D = (Dx2) * ZDim
     augmentedHessian.setOffDiagonalBlock(
-        i, m,
+        i,
+        m,
         FiT * b.segment<ZDim>(ZDim * i)  // F' * b
             -
             FiT * (Ei_P *
@@ -1405,7 +1432,8 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
       // Randomized seed, but fixed if we fix srand.
       unsigned seedShuffle = rand();
       // Randomize order.
-      std::shuffle(selectedIndices.begin(), selectedIndices.end(),
+      std::shuffle(selectedIndices.begin(),
+                   selectedIndices.end(),
                    std::default_random_engine(seedShuffle));
       // Take only first need_nr_features.
       selectedIndices.resize(need_nr_features);
@@ -1468,8 +1496,8 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
       // featureSelectionData.print();
       const gtsam::Cal3_S2& K = stereoFrame_km1->getLeftUndistRectCamMat();
       CameraParams cam_param;
-      cam_param.calibration_ =
-          gtsam::Cal3DS2(K.fx(), K.fy(), 0.0, K.px(), K.py(), 0.0, 0.0);
+      cam_param.distortion_ =
+          DistortionModel::make_pinhole(K.fx(), K.fy(), K.px(), K.py());
       cam_param.camera_matrix_ = cv::Mat::eye(3, 3, CV_64F);
       cam_param.camera_matrix_.at<double>(0, 0) = K.fx();
       cam_param.camera_matrix_.at<double>(1, 1) = K.fy();
@@ -1486,7 +1514,9 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
               successProbabilities,             // in [0,1] for each corner
               newlyAvailableKeypointsDistance,  // 0 if not available
               cam_param,  // note: corners are undistorted and rectified
-              need_nr_features, featureSelectionData, criterion);
+              need_nr_features,
+              featureSelectionData,
+              criterion);
       featureSelectionTime = UtilsOpenCV::GetTimeInSeconds() - startTime;
       UtilsOpenCV::PrintVector<size_t>(selectedIndices, "selectedIndices");
       UtilsOpenCV::PrintVector<double>(selectedGains, "selectedGains");
@@ -1547,7 +1577,8 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
       trackedSmartStereoMeasurements;
   trackedAndSelectedSmartStereoMeasurements.insert(
       trackedAndSelectedSmartStereoMeasurements.end(),
-      newSmartStereoMeasurements.begin(), newSmartStereoMeasurements.end());
+      newSmartStereoMeasurements.begin(),
+      newSmartStereoMeasurements.end());
   VLOG(20) << "Nr features tracked & selected "
            << trackedAndSelectedSmartStereoMeasurements.size();
 
@@ -1565,8 +1596,11 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
     // 255, 255), 4,selectedLmks,remId); UtilsOpenCV::DrawSquaresInPlace(img,
     // trackedKeypoints, cv::Scalar(0, 255, 0),10,trackedLmks,remId);
     std::vector<int> emptyVect;
-    UtilsOpenCV::DrawCrossesInPlace(img, newlyAvailableKeypoints,
-                                    cv::Scalar(0, 0, 255), 0.4, emptyVect,
+    UtilsOpenCV::DrawCrossesInPlace(img,
+                                    newlyAvailableKeypoints,
+                                    cv::Scalar(0, 0, 255),
+                                    0.4,
+                                    emptyVect,
                                     remId);
     UtilsOpenCV::DrawCirclesInPlace(
         img, selectedKeypoints, cv::Scalar(0, 255, 255), 4, emptyVect, remId);
@@ -1591,7 +1625,9 @@ FeatureSelector::splitTrackedAndNewFeatures_Select_Display(
                 "kf:" + std::to_string(vio_cur_id) +
                     " #tracked:" + std::to_string(trackedLmks.size()) +
                     " #selected:" + std::to_string(selectedLmks.size()),
-                KeypointCV(10, 15), CV_FONT_HERSHEY_COMPLEX, 0.4,
+                KeypointCV(10, 15),
+                CV_FONT_HERSHEY_COMPLEX,
+                0.4,
                 cv::Scalar(0, 255, 255));
 
     VLOG(20) << "trackedKeypoints: " << trackedKeypoints.size()

--- a/src/gtsam_distortion/CMakeLists.txt
+++ b/src/gtsam_distortion/CMakeLists.txt
@@ -1,0 +1,6 @@
+### Add source code for stereoVIO
+target_sources(kimera_vio
+  PRIVATE
+  "${CMAKE_CURRENT_LIST_DIR}/Cal3DS3.cpp"
+  "${CMAKE_CURRENT_LIST_DIR}/Cal3FS2.cpp"
+)

--- a/src/gtsam_distortion/Cal3DS3.cpp
+++ b/src/gtsam_distortion/Cal3DS3.cpp
@@ -1,0 +1,303 @@
+/* -*-c++-*--------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Bernd Pfrommer, based on code by
+ * Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Cal3DS3.cpp
+ * @brief Calibration of a camera with equidistant (fisheye) distortion model
+ * @date December 1st, 2018
+ * @author bernd.pfrommer@gmail.com
+ */
+
+#include "kimera-vio/gtsam_distortion/Cal3DS3.h"
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Point3.h>
+#include <string>
+
+/* ************************************************************************* */
+Cal3DS3::Cal3DS3(const gtsam::Vector& v)
+    : fx_(v[0]), fy_(v[1]), u0_(v[2]), v0_(v[3]), p1_(v[4]), p2_(v[5]) {
+  for (int i = 0; i < 6; i++) {
+    k_[i] = v[6 + i];
+  }
+}
+
+/* ************************************************************************* */
+gtsam::Matrix3 Cal3DS3::K() const {
+  gtsam::Matrix3 K;
+  K << fx_, 0, u0_, 0.0, fy_, v0_, 0.0, 0.0, 1.0;
+  return K;
+}
+
+/* ************************************************************************* */
+Eigen::Matrix<double, 12, 1> Cal3DS3::vector() const {
+  Eigen::Matrix<double, 12, 1> v;
+  v << fx_, fy_, u0_, v0_, p1_, p2_, k_[0], k_[1], k_[2], k_[3], k_[4], k_[5];
+  return v;
+}
+
+/* ************************************************************************* */
+void Cal3DS3::print(const std::string& s_) const {
+  gtsam::print((gtsam::Matrix)K(), s_ + ".K");
+  gtsam::print(gtsam::Vector(k()), s_ + ".k");
+}
+
+/* ************************************************************************* */
+bool Cal3DS3::equals(const Cal3DS3& K, double tol) const {
+  if (fabs(fx_ - K.fx_) > tol || fabs(fy_ - K.fy_) > tol ||
+      fabs(u0_ - K.u0_) > tol || fabs(v0_ - K.v0_) > tol ||
+      fabs(p1_ - K.p1_) > tol || fabs(p2_ - K.p2_) > tol ||
+      fabs(k_[0] - K.k_[0]) > tol || fabs(k_[1] - K.k_[1]) > tol ||
+      fabs(k_[2] - K.k_[2]) > tol || fabs(k_[3] - K.k_[3]) > tol ||
+      fabs(k_[4] - K.k_[4]) > tol || fabs(k_[5] - K.k_[5]) > tol) {
+    return false;
+  }
+  return true;
+}
+
+/* ************************************************************************* */
+static Eigen::Matrix<double, 2, 12> D2dcalibration(double x,
+                                                   double y,
+                                                   double xp,
+                                                   double yp,
+                                                   double x2,
+                                                   double y2,
+                                                   double xy,
+                                                   double R,
+                                                   double R2,
+                                                   double R3,
+                                                   double num,
+                                                   double deninv,
+                                                   const gtsam::Matrix2& DK) {
+  gtsam::Matrix24 DR1;
+  //     fx   fy   cx   cy
+  DR1 << xp, 0.0, 1.0, 0.0,  // du/d
+      0.0, yp, 0.0, 1.0;     // dv/d
+
+  const double mnumdeninv2 = -num * deninv * deninv;
+  double xdinv(x * deninv), ydinv(y * deninv);
+  double xf(x * mnumdeninv2), yf(y * mnumdeninv2);
+  gtsam::Matrix28 DR2;
+  // p1       p2      k1        k2       k3       k4    k5     k6
+  DR2 << 2 * xy, R + 2 * x2, xdinv * R, xdinv * R2, xdinv * R3, xf * R, xf * R2,
+      xf * R3,  // u
+      R + 2 * y2, 2 * xy, ydinv * R, ydinv * R2, ydinv * R3, yf * R, yf * R2,
+      yf * R3;  // v
+  Eigen::Matrix<double, 2, 12> D;
+  D << DR1, DK * DR2;
+  return D;
+}
+
+/* ************************************************************************* */
+static gtsam::Matrix2 D2dintrinsic(double x,
+                                   double y,
+                                   double x2,
+                                   double y2,
+                                   double xy,
+                                   double R,
+                                   double R2,
+                                   double fR,
+                                   double num,
+                                   double den,
+                                   double deninv,
+                                   double p1,
+                                   double p2,
+                                   double k1,
+                                   double k2,
+                                   double k3,
+                                   double k4,
+                                   double k5,
+                                   double k6,
+                                   const gtsam::Matrix2& DK) {
+  gtsam::Matrix2 DR;
+
+  const double p1x(p1 * x), p1y(p1 * y), p2x(p2 * x), p2y(p2 * y);
+  const double numprime = k1 + 2 * k2 * R + 3 * k3 * R2;
+  const double denprime = k4 + 2 * k5 * R + 3 * k6 * R2;
+  const double dfdR((numprime * den - num * denprime) * deninv * deninv);
+
+  DR <<  //            dx                      dy
+      fR + 2 * dfdR * x2 + 2 * p1y + 6 * p2x,
+      2 * xy * dfdR + 2 * p1x + 2 * p2y,  // du
+      2 * xy * dfdR + 2 * p1x + 2 * p2y,
+      fR + 2 * dfdR * y2 + 6 * p1y + 2 * p2x;  // dv
+
+  return DK * DR;
+}
+
+struct GeometricParams {
+  GeometricParams(double xa,
+                  double ya,
+                  double p1,
+                  double p2,
+                  double k1,
+                  double k2,
+                  double k3,
+                  double k4,
+                  double k5,
+                  double k6)
+      : x(xa), y(ya) {
+    x2 = x * x;
+    y2 = y * y;
+    xy = x * y;
+    R = x2 + y2;
+    R2 = R * R;
+    R3 = R2 * R;
+    num = 1 + k1 * R + k2 * R2 + k3 * R3;
+    den = 1 + k4 * R + k5 * R2 + k6 * R3;
+    deninv = 1.0 / den;
+    fR = num * deninv;
+    xp = x * fR + 2 * p1 * xy + p2 * (R + 2 * x2);
+    yp = y * fR + p1 * (R + 2 * y2) + 2 * p2 * xy;
+  }
+  double x, y;
+  double x2, y2, xy;
+  double R, R2, R3;
+  double fR, num, den, deninv;
+  double xp, yp;
+};
+
+gtsam::Point2 Cal3DS3::uncalibrateNoIntrinsics(const gtsam::Point2& p) const {
+  GeometricParams gp(
+      p.x(), p.y(), p1_, p2_, k_[0], k_[1], k_[2], k_[3], k_[4], k_[5]);
+  return gtsam::Point2(gp.xp, gp.yp);
+}
+
+/* ************************************************************************* */
+gtsam::Point2 Cal3DS3::uncalibrate(const gtsam::Point2& p,
+                                   gtsam::OptionalJacobian<2, 12> H1,
+                                   gtsam::OptionalJacobian<2, 2> H2) const {
+  GeometricParams gp(
+      p.x(), p.y(), p1_, p2_, k_[0], k_[1], k_[2], k_[3], k_[4], k_[5]);
+  gtsam::Matrix2 DK;
+  if (H1 || H2) DK << fx_, 0.0, 0.0, fy_;
+
+  // Derivative for calibration
+  if (H1)
+    *H1 = D2dcalibration(gp.x,
+                         gp.y,
+                         gp.xp,
+                         gp.yp,
+                         gp.x2,
+                         gp.y2,
+                         gp.xy,
+                         gp.R,
+                         gp.R2,
+                         gp.R3,
+                         gp.num,
+                         gp.deninv,
+                         DK);
+
+  // Derivative for points
+  if (H2) {
+    *H2 = D2dintrinsic(gp.x,
+                       gp.y,
+                       gp.x2,
+                       gp.y2,
+                       gp.xy,
+                       gp.R,
+                       gp.R2,
+                       gp.fR,
+                       gp.num,
+                       gp.den,
+                       gp.deninv,
+                       p1_,
+                       p2_,
+                       k_[0],
+                       k_[1],
+                       k_[2],
+                       k_[3],
+                       k_[4],
+                       k_[5],
+                       DK);
+  }
+
+  // Regular uncalibrate after distortion
+  return gtsam::Point2(fx_ * gp.xp + u0_, fy_ * gp.yp + v0_);
+}
+
+/* ************************************************************************* */
+gtsam::Point2 Cal3DS3::calibrate(const gtsam::Point2& pi,
+                                 const double tol) const {
+  // map from u,v -> x, y
+
+  const gtsam::Point2 invKPi((1 / fx_) * (pi.x() - u0_),
+                             (1 / fy_) * (pi.y() - v0_));
+
+  // initialize by ignoring the distortion at all, might be problematic for
+  // pixels around boundary
+  gtsam::Point2 pn = invKPi;
+
+  // iterate until the uncalibrate is close to the actual pixel coordinate
+  const int maxIterations = 10;
+  int iteration;
+  for (iteration = 0; iteration < maxIterations; ++iteration) {
+    const gtsam::Point2 xpyp = uncalibrateNoIntrinsics(pn);
+    if (distance2(xpyp, invKPi) <= tol) break;
+    pn = pn + invKPi - uncalibrateNoIntrinsics(pn);
+  }
+  if (iteration >= maxIterations)
+    throw std::runtime_error(
+        "Cal3DS3::calibrate fails to converge. need a better initialization");
+
+  return pn;
+}
+
+/* ************************************************************************* */
+gtsam::Matrix2 Cal3DS3::D2d_intrinsic(const gtsam::Point2& p) const {
+  GeometricParams gp(
+      p.x(), p.y(), p1_, p2_, k_[0], k_[1], k_[2], k_[3], k_[4], k_[5]);
+  gtsam::Matrix2 DK;
+  DK << fx_, 0.0, 0.0, fy_;
+  return (D2dintrinsic(gp.x,
+                       gp.y,
+                       gp.x2,
+                       gp.y2,
+                       gp.xy,
+                       gp.R,
+                       gp.R2,
+                       gp.fR,
+                       gp.num,
+                       gp.den,
+                       gp.deninv,
+                       p1_,
+                       p2_,
+                       k_[0],
+                       k_[1],
+                       k_[2],
+                       k_[3],
+                       k_[4],
+                       k_[5],
+                       DK));
+}
+
+/* ************************************************************************* */
+Eigen::Matrix<double, 2, 12> Cal3DS3::D2d_calibration(
+    const gtsam::Point2& p) const {
+  GeometricParams gp(
+      p.x(), p.y(), p1_, p2_, k_[0], k_[1], k_[2], k_[3], k_[4], k_[5]);
+  gtsam::Matrix2 DK;
+  DK << fx_, 0.0, 0.0, fy_;
+  return (D2dcalibration(gp.x,
+                         gp.y,
+                         gp.xp,
+                         gp.yp,
+                         gp.x2,
+                         gp.y2,
+                         gp.xy,
+                         gp.R,
+                         gp.R2,
+                         gp.R3,
+                         gp.num,
+                         gp.deninv,
+                         DK));
+}

--- a/src/gtsam_distortion/Cal3FS2.cpp
+++ b/src/gtsam_distortion/Cal3FS2.cpp
@@ -1,0 +1,271 @@
+/* -*-c++-*--------------------------------------------------------------------
+ * GTSAM Copyright 2010, Georgia Tech Research Corporation,
+ * Atlanta, Georgia 30332-0415
+ * All Rights Reserved
+ * Authors: Bernd Pfrommer, based on code by
+ * Frank Dellaert, et al. (see THANKS for the full author list)
+
+ * See LICENSE for the license information
+
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file Cal3FS2.cpp
+ * @brief Calibration of a camera with equidistant (fisheye) distortion model
+ * @date July 1st, 2018
+ * @author bernd.pfrommer@gmail.com
+ */
+
+#include "kimera-vio/gtsam_distortion/Cal3FS2.h"
+#include <gtsam/base/Matrix.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/geometry/Point2.h>
+#include <gtsam/geometry/Point3.h>
+#include <string>
+
+/* ************************************************************************* */
+Cal3FS2::Cal3FS2(const gtsam::Vector& v)
+    : fx_(v[0]),
+      fy_(v[1]),
+      u0_(v[2]),
+      v0_(v[3]),
+      k1_(v[4]),
+      k2_(v[5]),
+      k3_(v[6]),
+      k4_(v[7]) {}
+
+/* ************************************************************************* */
+gtsam::Matrix3 Cal3FS2::K() const {
+  gtsam::Matrix3 K;
+  K << fx_, 0, u0_, 0.0, fy_, v0_, 0.0, 0.0, 1.0;
+  return K;
+}
+
+/* ************************************************************************* */
+gtsam::Vector8 Cal3FS2::vector() const {
+  gtsam::Vector8 v;
+  v << fx_, fy_, u0_, v0_, k1_, k2_, k3_, k4_;
+  return v;
+}
+
+/* ************************************************************************* */
+void Cal3FS2::print(const std::string& s_) const {
+  gtsam::print((gtsam::Matrix)K(), s_ + ".K");
+  gtsam::print(gtsam::Vector(k()), s_ + ".k");
+}
+
+/* ************************************************************************* */
+bool Cal3FS2::equals(const Cal3FS2& K, double tol) const {
+  if (fabs(fx_ - K.fx_) > tol || fabs(fy_ - K.fy_) > tol ||
+      fabs(u0_ - K.u0_) > tol || fabs(v0_ - K.v0_) > tol ||
+      fabs(k1_ - K.k1_) > tol || fabs(k2_ - K.k2_) > tol ||
+      fabs(k3_ - K.k3_) > tol || fabs(k4_ - K.k4_) > tol)
+    return false;
+  return true;
+}
+
+/* ************************************************************************* */
+static gtsam::Matrix28 D2dcalibration(double x,
+                                      double y,
+                                      double xp,
+                                      double yp,
+                                      double x_r,
+                                      double y_r,
+                                      double theta3,
+                                      double theta5,
+                                      double theta7,
+                                      double theta9,
+                                      const gtsam::Matrix2& DK) {
+  gtsam::Matrix24 DR1;
+  //     fx   fy   cx   cy
+  DR1 << xp, 0.0, 1.0, 0.0,  // du/d
+      0.0, yp, 0.0, 1.0;     // dv/d
+
+  gtsam::Matrix24 DR2;
+  //        k1              k2            k3          k4
+  DR2 << x_r * theta3, x_r * theta5, x_r * theta7, x_r * theta9,  // du/d
+      y_r * theta3, y_r * theta5, y_r * theta7, y_r * theta9;     // dv/d
+
+  gtsam::Matrix28 D;
+  D << DR1, DK * DR2;
+  return D;
+}
+
+/* ************************************************************************* */
+static gtsam::Matrix2 D2dintrinsic(double r,
+                                   double r2,
+                                   double x_r,
+                                   double y_r,
+                                   double theta_d,
+                                   double theta,
+                                   double theta3,
+                                   double theta5,
+                                   double theta7,
+                                   double k1,
+                                   double k2,
+                                   double k3,
+                                   double k4,
+                                   const gtsam::Matrix2& DK) {
+  const double theta_d_r = (r < 1e-9) ? 1.0 : (theta_d / r);
+  const double dtheta_d_dtheta =
+      1 + theta * (k1 * 3 * theta + k2 * 5 * theta3 + k3 * 7 * theta5 +
+                   k4 * 9 * theta7);
+  const double dthetad_r_dr = dtheta_d_dtheta / (1 + r2) - theta_d_r;
+
+  gtsam::Matrix2 DR;
+
+  DR <<  //            dx                      dy
+      theta_d_r + x_r * x_r * dthetad_r_dr,
+      x_r * y_r * dthetad_r_dr,                                        // du
+      x_r * y_r * dthetad_r_dr, theta_d_r + y_r * y_r * dthetad_r_dr;  // dv
+
+  return DK * DR;
+}
+
+struct GeometricParams {
+  GeometricParams(double xa,
+                  double ya,
+                  double k1,
+                  double k2,
+                  double k3,
+                  double k4,
+                  double tol = 1e-9)
+      : x(xa), y(ya) {
+    const double xx = x * x, yy = y * y;
+    rr = xx + yy;
+    r = std::sqrt(rr);
+    theta = std::atan(r);
+    theta2 = theta * theta;
+    theta3 = theta * theta2;
+    theta5 = theta3 * theta2;
+    theta7 = theta5 * theta2;
+    theta9 = theta7 * theta2;
+    theta_d = theta + k1 * theta3 + k2 * theta5 + k3 * theta7 + k4 * theta9;
+    x_r = (r < tol) ? 1.0 : x / r;
+    y_r = (r < tol) ? 1.0 : y / r;
+    xp = theta_d * x_r;
+    yp = theta_d * y_r;
+  }
+  double r, rr;
+  double x, y;
+  double theta, theta2, theta3, theta5, theta7, theta9;
+  double theta_d;
+  double x_r, y_r;
+  double xp, yp;
+};
+
+gtsam::Point2 Cal3FS2::uncalibrateNoIntrinsics(const gtsam::Point2& p) const {
+  GeometricParams gp(p.x(), p.y(), k1_, k2_, k3_, k4_, 1e-9);
+  return gtsam::Point2(gp.xp, gp.yp);
+}
+
+/* ************************************************************************* */
+gtsam::Point2 Cal3FS2::uncalibrate(const gtsam::Point2& p,
+                                   gtsam::OptionalJacobian<2, 8> H1,
+                                   gtsam::OptionalJacobian<2, 2> H2) const {
+  GeometricParams gp(p.x(), p.y(), k1_, k2_, k3_, k4_, 1e-9);
+  gtsam::Matrix2 DK;
+  if (H1 || H2) DK << fx_, 0.0, 0.0, fy_;
+
+  // Derivative for calibration
+  if (H1)
+    *H1 = D2dcalibration(gp.x,
+                         gp.y,
+                         gp.xp,
+                         gp.yp,
+                         gp.x_r,
+                         gp.y_r,
+                         gp.theta3,
+                         gp.theta5,
+                         gp.theta7,
+                         gp.theta9,
+                         DK);
+
+  // Derivative for points
+  if (H2)
+    *H2 = D2dintrinsic(gp.r,
+                       gp.rr,
+                       gp.x_r,
+                       gp.y_r,
+                       gp.theta_d,
+                       gp.theta,
+                       gp.theta3,
+                       gp.theta5,
+                       gp.theta7,
+                       k1_,
+                       k2_,
+                       k3_,
+                       k4_,
+                       DK);
+
+  // Regular uncalibrate after distortion
+  return gtsam::Point2(fx_ * gp.xp + u0_, fy_ * gp.yp + v0_);
+}
+
+/* ************************************************************************* */
+gtsam::Point2 Cal3FS2::calibrate(const gtsam::Point2& pi,
+                                 const double tol) const {
+  // map from u,v -> x, y
+
+  const gtsam::Point2 invKPi((1 / fx_) * (pi.x() - u0_),
+                             (1 / fy_) * (pi.y() - v0_));
+
+  // initialize by ignoring the distortion at all, might be problematic for
+  // pixels around boundary
+  gtsam::Point2 pn = invKPi;
+
+  // iterate until the uncalibrate is close to the actual pixel coordinate
+  const int maxIterations = 10;
+  int iteration;
+  for (iteration = 0; iteration < maxIterations; ++iteration) {
+    const gtsam::Point2 xpyp = uncalibrateNoIntrinsics(pn);
+    if (distance2(xpyp, invKPi) <= tol) break;
+    pn = pn + invKPi - uncalibrateNoIntrinsics(pn);
+  }
+  if (iteration >= maxIterations)
+    throw std::runtime_error(
+        "Cal3FS2::calibrate fails to converge. need a better initialization");
+
+  return pn;
+}
+
+/* ************************************************************************* */
+gtsam::Matrix2 Cal3FS2::D2d_intrinsic(const gtsam::Point2& p) const {
+  GeometricParams gp(p.x(), p.y(), k1_, k2_, k3_, k4_, 1e-9);
+  gtsam::Matrix2 DK;
+  DK << fx_, 0.0, 0.0, fy_;
+  return (D2dintrinsic(gp.r,
+                       gp.rr,
+                       gp.x_r,
+                       gp.y_r,
+                       gp.theta_d,
+                       gp.theta,
+                       gp.theta3,
+                       gp.theta5,
+                       gp.theta7,
+                       k1_,
+                       k2_,
+                       k3_,
+                       k4_,
+                       DK));
+}
+
+/* ************************************************************************* */
+gtsam::Matrix28 Cal3FS2::D2d_calibration(const gtsam::Point2& p) const {
+  GeometricParams gp(p.x(), p.y(), k1_, k2_, k3_, k4_, 1e-9);
+  gtsam::Matrix2 DK;
+  DK << fx_, 0.0, 0.0, fy_;
+
+  // Derivative for calibration
+  return (D2dcalibration(gp.x,
+                         gp.y,
+                         gp.xp,
+                         gp.yp,
+                         gp.x_r,
+                         gp.y_r,
+                         gp.theta3,
+                         gp.theta5,
+                         gp.theta7,
+                         gp.theta9,
+                         DK));
+}

--- a/tests/testDistortionModels.cpp
+++ b/tests/testDistortionModels.cpp
@@ -1,0 +1,238 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   testDistortionModels.h
+ * @brief  tests the distortion models
+ * @author Bernd Pfrommer
+ */
+#include "kimera-vio/distortion_models/DistortionModel.h"
+
+#include <opencv2/calib3d.hpp>
+#include <opencv2/core/mat.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <utility>
+#include <vector>
+
+DECLARE_string(test_data_path);
+
+/* ************************************************************************** */
+
+// turn intrinsics into K matrix
+static cv::Mat make_K_matrix(const std::vector<double> intr) {
+  double v[9] = {intr[0], 0, intr[2], 0, intr[1], intr[3], 0, intr[1], 1};
+  const cv::Mat K = cv::Mat(3, 3, CV_64F, &v[0]);
+  return (K.clone());
+}
+
+// lift 2d points to 3d
+static std::vector<cv::Point3f> make_homogeneous(
+    const std::vector<cv::Point2f>& v) {
+  std::vector<cv::Point3f> h;
+  for (const auto& p : v) {
+    h.push_back(cv::Point3f(p.x, p.y, 1.0));
+  }
+  return (h);
+}
+
+// generate test data common for all tests
+static std::vector<cv::Point2f> make_test_data(
+    cv::Mat* K,
+    std::vector<double>* intrinsics,
+    std::vector<double>* dist_coeff) {
+  // camera resolution
+  const int res[2] = {640, 400};
+  // distortion coefficients
+  const std::vector<double> dc = {0.03, -0.02, 0.01, -0.005};
+  *dist_coeff = dc;
+  // camera intrinsics
+  const double u_off = -10.0;
+  const double v_off = 5.0;
+  // note: shift the image center slightly
+  const std::vector<double> intr = {
+      640.0, 635.0, res[0] / 2 + u_off, res[1] / 2 + v_off};
+  *intrinsics = intr;
+  // convert intrinsics to K matrix
+  *K = make_K_matrix(intr);
+
+  // test points: distorted (u,v) on-sensor points
+  // note: due to the center shift, the last one is actually
+  // where the optical axis meets the sensor
+  const std::vector<cv::Point2f> pts = {
+      cv::Point2f(0, 0),                    // top left corners
+      cv::Point2f(res[0] - 1, res[1] - 1),  // bottom right corner
+      cv::Point2f(res[0] / 2, res[1] / 2),  // center
+      cv::Point2f(res[0] / 2 + u_off, res[1] / 2 + v_off)};  // shifted center
+  return pts;
+}
+
+// helper function to uncalibrate set of points
+static std::vector<cv::Point2f> uncalibrate(
+    const VIO::DistortionModelPtr& dm,
+    const std::vector<cv::Point2f>& undist) {
+  std::vector<cv::Point2f> uncalib;
+  for (const auto& p : undist) {
+    const gtsam::Point2 uc = dm->uncalibrate(gtsam::Point2(p.x, p.y));
+    uncalib.push_back(cv::Point2f(uc(0), uc(1)));
+  }
+  return (uncalib);
+}
+
+// helper function to project set of points
+static std::vector<cv::Point2f> project(const VIO::DistortionModelPtr& dm,
+                                        const std::vector<cv::Point3f>& p3d) {
+  std::vector<cv::Point2f> proj;
+  for (const auto& p : p3d) {
+    const gtsam::Point2 pp =
+        dm->project(gtsam::Pose3(), gtsam::Point3(p.x, p.y, p.z));
+    proj.push_back(cv::Point2f(pp(0), pp(1)));
+  }
+  return (proj);
+}
+
+// common code for radtan uncalibration testing
+static void test_radtan_uncalibrate(const std::vector<double>& extra_coeff) {
+  cv::Mat K;
+  std::vector<double> dist_coeff, intrinsics;
+  // make test data common for all models
+  const std::vector<cv::Point2f> dist =
+      make_test_data(&K, &intrinsics, &dist_coeff);
+  // now add extra coefficients to back
+  dist_coeff.insert(dist_coeff.end(), extra_coeff.begin(), extra_coeff.end());
+
+  VIO::DistortionModelPtr dm =
+      VIO::DistortionModel::make("radtan", intrinsics, dist_coeff);
+
+  // first undistort the points using opencv
+  std::vector<cv::Point2f> undist;
+  cv::undistortPoints(dist, undist, K, dist_coeff);
+
+  // now redistort the points using opencv.
+  // This is necessary because the undistortion in opencv
+  // is not super precise, and when many large k coefficients
+  // are used, opencv does not exactly recover the original values
+  // during a round trip.
+  std::vector<cv::Point3f> undist_h = make_homogeneous(undist);
+  cv::Mat rvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  cv::Mat tvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  std::vector<cv::Point2f> redist;  // redistorted
+  // use project function to distort points again
+  cv::projectPoints(undist_h, rvec, tvec, K, dist_coeff, redist);
+
+  std::vector<cv::Point2f> uncalib = uncalibrate(dm, undist);
+  // Check against the redistorted points,
+  // not the original ones!
+  for (int i = 0; i < undist.size(); i++) {
+    EXPECT_NEAR(uncalib[i].x, redist[i].x, 1e-6);
+    EXPECT_NEAR(uncalib[i].y, redist[i].y, 1e-6);
+  }
+}
+
+// common code for radtan projection testing
+static void test_radtan_project(const std::vector<double>& extra_coeff) {
+  cv::Mat K;
+  std::vector<double> dist_coeff, intrinsics;
+  const std::vector<cv::Point2f> dist =
+      make_test_data(&K, &intrinsics, &dist_coeff);
+  // now add extra coefficients to back
+  dist_coeff.insert(dist_coeff.end(), extra_coeff.begin(), extra_coeff.end());
+
+  VIO::DistortionModelPtr dm =
+      VIO::DistortionModel::make("radtan", intrinsics, dist_coeff);
+
+  std::vector<cv::Point2f> undist;
+  cv::undistortPoints(dist, undist, K, dist_coeff);
+  std::vector<cv::Point3f> undist_h = make_homogeneous(undist);
+  cv::Mat rvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  cv::Mat tvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  std::vector<cv::Point2f> proj;  // opencv projected points
+  cv::projectPoints(undist_h, rvec, tvec, K, dist_coeff, proj);
+
+  std::vector<cv::Point2f> proj_dm = project(dm, undist_h);
+  // check against opencv projection
+  for (int i = 0; i < proj.size(); i++) {
+    EXPECT_NEAR(proj_dm[i].x, proj[i].x, 1e-5);
+    EXPECT_NEAR(proj_dm[i].y, proj[i].y, 1e-5);
+  }
+}
+
+TEST(testDistortionModels, uncalibrateEquidistant) {
+  cv::Mat K;
+  std::vector<double> dist_coeff, intrinsics;
+
+  const std::vector<cv::Point2f> dist =
+      make_test_data(&K, &intrinsics, &dist_coeff);
+
+  VIO::DistortionModelPtr dm =
+      VIO::DistortionModel::make("equidistant", intrinsics, dist_coeff);
+
+  std::vector<cv::Point2f> undist;
+  cv::fisheye::undistortPoints(dist, undist, K, dist_coeff);
+  std::vector<cv::Point2f> uncalib = uncalibrate(dm, undist);
+  // check against original, distorted points
+  for (int i = 0; i < dist.size(); i++) {
+    EXPECT_NEAR(uncalib[i].x, dist[i].x, 1e-5);
+    EXPECT_NEAR(uncalib[i].y, dist[i].y, 1e-5);
+  }
+}
+
+TEST(testDistortionModels, uncalibrateRadTan4) {
+  const std::vector<double> extra_coeff;
+  test_radtan_uncalibrate(extra_coeff);
+}
+
+TEST(testDistortionModels, uncalibrateRadTan8) {
+  // to find trouble, pick large k3..k6
+  const std::vector<double> extra_coeff = {0.5, -0.3, 0.2, -0.1};
+  test_radtan_uncalibrate(extra_coeff);
+}
+
+TEST(testDistortionModels, projectEquidistant) {
+  cv::Mat K;
+  std::vector<double> dist_coeff, intrinsics;
+
+  const std::vector<cv::Point2f> dist =
+      make_test_data(&K, &intrinsics, &dist_coeff);
+
+  VIO::DistortionModelPtr dm =
+      VIO::DistortionModel::make("equidistant", intrinsics, dist_coeff);
+
+  std::vector<cv::Point2f> undist;
+  cv::fisheye::undistortPoints(dist, undist, K, dist_coeff);
+  std::vector<cv::Point3f> undist_h = make_homogeneous(undist);
+  cv::Mat rvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  cv::Mat tvec = (cv::Mat_<double>(3, 1) << 0, 0, 0);
+  std::vector<cv::Point2f> proj;  // opencv projected points
+  cv::fisheye::projectPoints(undist_h, proj, rvec, tvec, K, dist_coeff);
+
+  std::vector<cv::Point2f> proj_dm = project(dm, undist_h);
+  // check against opencv projection
+  for (int i = 0; i < proj.size(); i++) {
+    EXPECT_NEAR(proj_dm[i].x, proj[i].x, 1e-5);
+    EXPECT_NEAR(proj_dm[i].y, proj[i].y, 1e-5);
+  }
+}
+
+TEST(testDistortionModels, projectRadTan4) {
+  const std::vector<double> extra_coeff;
+  test_radtan_project(extra_coeff);
+}
+
+TEST(testDistortionModels, projectRadTan8) {
+  // to find trouble, pick large k3..k6
+  const std::vector<double> extra_coeff = {0.5, -0.3, 0.2, -0.1};
+  test_radtan_project(extra_coeff);
+}

--- a/tests/testFeatureSelector.cpp
+++ b/tests/testFeatureSelector.cpp
@@ -27,6 +27,9 @@
 
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <limits>
+#include <vector>
 
 #include "kimera-vio/frontend/FeatureSelector.h"
 
@@ -1059,9 +1062,8 @@ TEST(FeatureSelector, DISABLED_featureSelection) {
 
   // create camera params
   CameraParams cam_param;
-  cam_param.calibration_ =
-      Cal3DS2(Kreal.fx(), Kreal.fy(), 0.0, Kreal.px(), Kreal.py(), 0.0,
-              0.0);  // 0 skew and no distortion
+  cam_param.distortion_ = DistortionModel::make_pinhole(
+      Kreal.fx(), Kreal.fy(), Kreal.px(), Kreal.py());
   cam_param.camera_matrix_ = Mat::eye(3, 3, CV_64F);
   cam_param.camera_matrix_.at<double>(0, 0) = Kreal.fx();
   cam_param.camera_matrix_.at<double>(1, 1) = Kreal.fy();

--- a/tests/testFrame.cpp
+++ b/tests/testFrame.cpp
@@ -16,6 +16,8 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <string>
+#include <vector>
 
 #include "kimera-vio/frontend/Frame.h"
 
@@ -121,7 +123,7 @@ TEST(testFrame, CalibratePixel) {
     // distort the pixel again
     versor = versor / versor(2);
     Point2 uncalibrated_px_actual =
-        camParams.calibration_.uncalibrate(Point2(versor(0), versor(1)));
+        camParams.distortion_->uncalibrate(Point2(versor(0), versor(1)));
     Point2 uncalibrated_px_expected = Point2(iter->x, iter->y);
     Point2 px_mismatch = uncalibrated_px_actual - uncalibrated_px_expected;
     ASSERT_TRUE(px_mismatch.vector().norm() < 0.5);
@@ -159,9 +161,9 @@ TEST(testFrame, DISABLED_CalibratePixel) {
     // distort the pixel again
     versor = versor / versor(2);
     Point2 uncalibrated_px_actual =
-camParams.calibration_.uncalibrate(Point2(versor(0), versor(1))); Point2
-uncalibrated_px_expected = Point2(iter->x, iter->y); Point2 px_mismatch =
-uncalibrated_px_actual - uncalibrated_px_expected;
+        camParams.distortion_->uncalibrate(Point2(versor(0), versor(1)));
+    Point2 uncalibrated_px_expected = Point2(iter->x, iter->y);
+    Point2 px_mismatch = uncalibrated_px_actual - uncalibrated_px_expected;
     ASSERT_TRUE(px_mismatch.vector().norm() < 0.5);
   }
 }

--- a/tests/testStereoFrame.cpp
+++ b/tests/testStereoFrame.cpp
@@ -131,8 +131,8 @@ static cv::Mat cvTranslateImageX(cv::Mat img, double dist) {
   cv::Mat result = cv::Mat(img.rows, img.cols, img.type());
   cv::Mat translation_mat = cv::Mat::eye(3, 3, CV_64F);
   translation_mat.at<double>(0, 2) = dist;
-  cv::warpPerspective(img, result, translation_mat, img.size(),
-                      cv::INTER_NEAREST);
+  cv::warpPerspective(
+      img, result, translation_mat, img.size(), cv::INTER_NEAREST);
   return result;
 }
 
@@ -289,9 +289,16 @@ TEST_F(StereoFrameFixture, findMatchingKeypointRectified) {
         int stripe_rows = templ_rows + 4;
         double matchingVal_LR;
         // actual keypoint
-        tie(right_pt, matchingVal_LR) = sf->findMatchingKeypointRectified(
-            left_img, left_pt, right_img, templ_cols, templ_rows, stripe_cols,
-            stripe_rows, tol_corr, false);
+        tie(right_pt, matchingVal_LR) =
+            sf->findMatchingKeypointRectified(left_img,
+                                              left_pt,
+                                              right_img,
+                                              templ_cols,
+                                              templ_rows,
+                                              stripe_cols,
+                                              stripe_rows,
+                                              tol_corr,
+                                              false);
 
         // Judging the correctness of the matches.
         double y_left = left_pt.y;
@@ -431,7 +438,8 @@ TEST_F(StereoFrameFixture, DistortUnrectifyPoints) {
 
   tie(keypoints_unrectified, keypoints_status) =
       StereoFrame::distortUnrectifyPoints(
-          keypoints_rectified, sf->getLeftFrame().cam_param_.undistRect_map_x_,
+          keypoints_rectified,
+          sf->getLeftFrame().cam_param_.undistRect_map_x_,
           sf->getLeftFrame().cam_param_.undistRect_map_y_);
 
   // Manually compute the expected distorted/unrectified keypoints!
@@ -451,7 +459,8 @@ TEST_F(StereoFrameFixture, DistortUnrectifyPoints) {
     // if it is VALID, compare actual pixel value against manually computed
     // expected value
     Mat pt = (cv::Mat_<double>(3, 1) << keypoints_rectified[i].second.x,
-              keypoints_rectified[i].second.y, 1);  // homogeneous pixel
+              keypoints_rectified[i].second.y,
+              1);  // homogeneous pixel
     Mat P1_inv = P1(cv::Rect(0, 0, 3, 3)).inv();
     Mat R = sf->getLeftFrame().cam_param_.R_rectify_;
     Mat xn = R.t() * P1_inv * pt;
@@ -461,7 +470,7 @@ TEST_F(StereoFrameFixture, DistortUnrectifyPoints) {
             xn.at<double>(
                 2, 0));  // convert back to pixel (non-homogeneous coordinates)
     Point2 pt_expected =
-        sf->getLeftFrame().cam_param_.calibration_.uncalibrate(pt_in);
+        sf->getLeftFrame().cam_param_.distortion_->uncalibrate(pt_in);
 
     // actual value
     Point2 pt_actual =
@@ -492,26 +501,28 @@ TEST_F(StereoFrameFixture, undistortRectifyPoints) {
 
   // Actual value
   StatusKeypointsCV keypoints_rectified;
-  sf->undistortRectifyPoints(
-      keypoints_unrectified_gt, sf->getLeftFrame().cam_param_,
-      sf->getLeftUndistRectCamMat(), &keypoints_rectified);
+  sf->undistortRectifyPoints(keypoints_unrectified_gt,
+                             sf->getLeftFrame().cam_param_,
+                             sf->getLeftUndistRectCamMat(),
+                             &keypoints_rectified);
 
   // Map back!
   KeypointsCV keypoints_unrectified_actual;
   std::vector<KeypointStatus> status_unrectified;
   tie(keypoints_unrectified_actual, status_unrectified) =
       StereoFrame::distortUnrectifyPoints(
-          keypoints_rectified, sf->getLeftFrame().cam_param_.undistRect_map_x_,
+          keypoints_rectified,
+          sf->getLeftFrame().cam_param_.undistRect_map_x_,
           sf->getLeftFrame().cam_param_.undistRect_map_y_);
 
   // Comparision
   for (int i = 0; i < keypoints_unrectified_actual.size(); i++) {
     if (keypoints_rectified[i].first != KeypointStatus::VALID) continue;
     // compare pixel coordinates of valid points
-    EXPECT_NEAR(keypoints_unrectified_actual[i].x,
-                keypoints_unrectified_gt[i].x, 1);
-    EXPECT_NEAR(keypoints_unrectified_actual[i].y,
-                keypoints_unrectified_gt[i].y, 1);
+    EXPECT_NEAR(
+        keypoints_unrectified_actual[i].x, keypoints_unrectified_gt[i].x, 1);
+    EXPECT_NEAR(
+        keypoints_unrectified_actual[i].y, keypoints_unrectified_gt[i].y, 1);
   }
 }
 
@@ -556,9 +567,13 @@ TEST_F(StereoFrameFixture, getDepthFromRectifiedMatches) {
         double x_loc = x2depth * depth;
         double y_loc = y2depth * depth;
 
-        Mat pt_mat_left = P1 * (cv::Mat_<double>(4, 1) << x_loc, y_loc, depth,
+        Mat pt_mat_left = P1 * (cv::Mat_<double>(4, 1) << x_loc,
+                                y_loc,
+                                depth,
                                 1);  // project to left
-        Mat pt_mat_right = P2 * (cv::Mat_<double>(4, 1) << x_loc, y_loc, depth,
+        Mat pt_mat_right = P2 * (cv::Mat_<double>(4, 1) << x_loc,
+                                 y_loc,
+                                 depth,
                                  1);  // project to right
         pt_mat_left =
             pt_mat_left / pt_mat_left.at<double>(2, 0);  // express as pixels
@@ -667,8 +682,10 @@ TEST_F(StereoFrameFixture, getRightKeypointsRectified) {
 
       // get actual matches
       StatusKeypointsCV right_keypoints_rectified =
-          sf->getRightKeypointsRectified(left_img, right_img,
-                                         left_keypoints_rectified, 458.654,
+          sf->getRightKeypointsRectified(left_img,
+                                         right_img,
+                                         left_keypoints_rectified,
+                                         458.654,
                                          sf->getBaseline());
 
       for (size_t i = 0; i < left_keypoints_rectified.size();
@@ -744,13 +761,17 @@ TEST_F(StereoFrameFixture, sparseStereoMatching) {
   // check that data is correctly populated:
   EXPECT_NEAR(0.110078, sfnew->getBaseline(), 1e-5);
   EXPECT_NEAR(100, sfnew->getRightFrame().keypoints_.size(), 1e-5);
-  EXPECT_NEAR(0, sfnew->getRightFrame().scores_.size(),
+  EXPECT_NEAR(0,
+              sfnew->getRightFrame().scores_.size(),
               1e-5);  // scores do not get populated
-  EXPECT_NEAR(0, sfnew->getRightFrame().landmarks_.size(),
+  EXPECT_NEAR(0,
+              sfnew->getRightFrame().landmarks_.size(),
               1e-5);  // landmarks_ do not get populated
-  EXPECT_NEAR(0, sfnew->getRightFrame().landmarksAge_.size(),
+  EXPECT_NEAR(0,
+              sfnew->getRightFrame().landmarksAge_.size(),
               1e-5);  // landmarksAges do not get populated
-  EXPECT_NEAR(0, sfnew->getRightFrame().versors_.size(),
+  EXPECT_NEAR(0,
+              sfnew->getRightFrame().versors_.size(),
               1e-5);  // landmarksAges do not get populated
   EXPECT_NEAR(100, sfnew->keypoints_depth_.size(), 1e-5);
   EXPECT_NEAR(100, sfnew->keypoints_3d_.size(), 1e-5);
@@ -805,10 +826,11 @@ TEST_F(StereoFrameFixture, sparseStereoMatching) {
       versor_i =
           versor_i / versor_i(2);  // set last element to 1, instead of norm 1
       Point2 kp_i_distUnrect_gtsam =
-          sfnew->getLeftFrame().cam_param_.calibration_.uncalibrate(
+          sfnew->getLeftFrame().cam_param_.distortion_->uncalibrate(
               Point2(versor_i(0), versor_i(1)));
       EXPECT_TRUE(assert_equal(Point2(kp_i_distUnrect.x, kp_i_distUnrect.y),
-                               kp_i_distUnrect_gtsam, 1));
+                               kp_i_distUnrect_gtsam,
+                               1));
 
       // TEST: uncalibrateUndistRect(versor) = original distorted unrectified
       // point (CHECK UNDIST RECT CALIBRATION WORKS)
@@ -826,7 +848,8 @@ TEST_F(StereoFrameFixture, sparseStereoMatching) {
       Point2 kp_i_undistRect_gtsam =
           KundistRect.uncalibrate(Point2(versor_i(0), versor_i(1)));
       EXPECT_TRUE(assert_equal(Point2(kp_i_undistRect.x, kp_i_undistRect.y),
-                               kp_i_undistRect_gtsam, 1));
+                               kp_i_undistRect_gtsam,
+                               1));
 
       // TEST: distortUnrectify(undistRectified) = original distorted
       // unrectified point (CHECK UNDISTORTION WORKS)
@@ -835,40 +858,43 @@ TEST_F(StereoFrameFixture, sparseStereoMatching) {
       StatusKeypointsCV urp;
       urp.push_back(make_pair(KeypointStatus::VALID, kp_i_undistRect));
       tie(dup, statuses) = StereoFrame::distortUnrectifyPoints(
-          urp, sfnew->getLeftFrame().cam_param_.undistRect_map_x_,
+          urp,
+          sfnew->getLeftFrame().cam_param_.undistRect_map_x_,
           sfnew->getLeftFrame().cam_param_.undistRect_map_y_);
       EXPECT_TRUE(assert_equal(Point2(kp_i_distUnrect.x, kp_i_distUnrect.y),
-                               Point2(dup.at(0).x, dup.at(0).y), 1));
+                               Point2(dup.at(0).x, dup.at(0).y),
+                               1));
 
       // TEST: projecting 3d point to left camera (undist and rectified) =
       // original undistorted rectified point (CHECK BACKPROJECTION WORKS)
       Point3 point3d = sfnew->keypoints_3d_.at(i);
       PinholeCamera<Cal3_S2> leftCam_undistRect(gtsam::Pose3(), KundistRect);
       Point2 p2_undistRect = leftCam_undistRect.project(point3d);
-      EXPECT_TRUE(assert_equal(Point2(kp_i_undistRect.x, kp_i_undistRect.y),
-                               p2_undistRect, 1));
+      EXPECT_TRUE(assert_equal(
+          Point2(kp_i_undistRect.x, kp_i_undistRect.y), p2_undistRect, 1));
 
       // TEST: projecting 3d point to left camera (distorted and unrectified) =
       // original distorted unrectified point (CHECK BACKPROJECTION WORKS)
       Point3 point3d_unrect = actual_camL_R_camLrect.rotate(
           point3d);  // compensate for the rotation induced by rectification
-      Cal3DS2 KdistUnrect = sfnew->getLeftFrame().cam_param_.calibration_;
-      PinholeCamera<Cal3DS2> leftCam_distUnrect(gtsam::Pose3(), KdistUnrect);
-      Point2 p2_distUnrect = leftCam_distUnrect.project(point3d_unrect);
-      EXPECT_TRUE(assert_equal(Point2(kp_i_distUnrect.x, kp_i_distUnrect.y),
-                               p2_distUnrect, 1));
+      Point2 p2_distUnrect =
+          sfnew->getLeftFrame().cam_param_.distortion_->project(Pose3(),
+                                                                point3d_unrect);
+      EXPECT_TRUE(assert_equal(
+          Point2(kp_i_distUnrect.x, kp_i_distUnrect.y), p2_distUnrect, 1));
 
       // TEST: projecting 3d point to stereo camera
       // reproject to camera and check that matches corresponding rectified
       // pixels
       Cal3_S2 sfnew_left_undist_rect_cam_mat_2 =
           sfnew->getLeftUndistRectCamMat();
-      Cal3_S2Stereo::shared_ptr K(new Cal3_S2Stereo(
-          sfnew_left_undist_rect_cam_mat_2.fx(),
-          sfnew_left_undist_rect_cam_mat_2.fy(),
-          sfnew_left_undist_rect_cam_mat_2.skew(),
-          sfnew_left_undist_rect_cam_mat_2.px(),
-          sfnew_left_undist_rect_cam_mat_2.py(), sfnew->getBaseline()));
+      Cal3_S2Stereo::shared_ptr K(
+          new Cal3_S2Stereo(sfnew_left_undist_rect_cam_mat_2.fx(),
+                            sfnew_left_undist_rect_cam_mat_2.fy(),
+                            sfnew_left_undist_rect_cam_mat_2.skew(),
+                            sfnew_left_undist_rect_cam_mat_2.px(),
+                            sfnew_left_undist_rect_cam_mat_2.py(),
+                            sfnew->getBaseline()));
       // Note: camera pose is the identity (instead of
       // sfnew->getBPoseCamLRect()) since the 3D point is in the left camera
       // frame
@@ -877,7 +903,8 @@ TEST_F(StereoFrameFixture, sparseStereoMatching) {
       EXPECT_NEAR(sp2.uL(), sfnew->left_keypoints_rectified_.at(i).x, 1);
       EXPECT_NEAR(sp2.v(), sfnew->left_keypoints_rectified_.at(i).y, 1);
       EXPECT_NEAR(sp2.uR(), sfnew->right_keypoints_rectified_.at(i).x, 1);
-      EXPECT_NEAR(sp2.v(), sfnew->right_keypoints_rectified_.at(i).y,
+      EXPECT_NEAR(sp2.v(),
+                  sfnew->right_keypoints_rectified_.at(i).y,
                   3);  // slightly larger errors
     }
   }
@@ -1064,11 +1091,16 @@ TEST(testStereoFrame, undistortFisheye) {
         cv::Mat::eye(3, 3, CV_32F),
         // don't to use default identity!
         cam_params_left_fisheye.camera_matrix_,
-        cam_params_left_fisheye.image_size_, CV_32FC1,
+        cam_params_left_fisheye.image_size_,
+        CV_32FC1,
         // output
-        map_x_fisheye_undist, map_y_fisheye_undist);
-    cv::remap(left_fisheye_image_dist, left_fisheye_image_undist,
-              map_x_fisheye_undist, map_y_fisheye_undist, cv::INTER_LINEAR);
+        map_x_fisheye_undist,
+        map_y_fisheye_undist);
+    cv::remap(left_fisheye_image_dist,
+              left_fisheye_image_undist,
+              map_x_fisheye_undist,
+              map_y_fisheye_undist,
+              cv::INTER_LINEAR);
   } else {
     LOG(ERROR) << "Distortion model is not pinhole equidistant.";
   }
@@ -1129,15 +1161,19 @@ TEST_F(StereoFrameFixture, DISABLED_undistortFisheyeStereoFrame) {
   Frame left_frame_fish = sf->getLeftFrame();
   Frame right_frame_fish = sf->getRightFrame();
   left_frame_fish.extractCorners();
-  sf->undistortRectifyPoints(
-      left_frame_fish.keypoints_, left_frame_fish.cam_param_,
-      left_undistRectCameraMatrix_fisheye, &left_keypoints_rectified);
+  sf->undistortRectifyPoints(left_frame_fish.keypoints_,
+                             left_frame_fish.cam_param_,
+                             left_undistRectCameraMatrix_fisheye,
+                             &left_keypoints_rectified);
 
   // Get rectified right keypoints
   StatusKeypointsCV right_keypoints_rectified;
-  right_keypoints_rectified = sf->getRightKeypointsRectified(
-      left_image_rectified, right_image_rectified, left_keypoints_rectified,
-      left_undistRectCameraMatrix_fisheye.fx(), sf->getBaseline());
+  right_keypoints_rectified =
+      sf->getRightKeypointsRectified(left_image_rectified,
+                                     right_image_rectified,
+                                     left_keypoints_rectified,
+                                     left_undistRectCameraMatrix_fisheye.fx(),
+                                     sf->getBaseline());
 
   // Check corresponding features are on epipolar lines (visually and store)
   cv::Mat undist_sidebyside = UtilsOpenCV::ConcatenateTwoImages(
@@ -1149,9 +1185,11 @@ TEST_F(StereoFrameFixture, DISABLED_undistortFisheyeStereoFrame) {
                  cv::IMREAD_ANYCOLOR);
 
   // Get keypoints depth
-  std::vector<double> keypoints_depth = sf->getDepthFromRectifiedMatches(
-      left_keypoints_rectified, right_keypoints_rectified,
-      left_undistRectCameraMatrix_fisheye.fx(), sf->getBaseline());
+  std::vector<double> keypoints_depth =
+      sf->getDepthFromRectifiedMatches(left_keypoints_rectified,
+                                       right_keypoints_rectified,
+                                       left_undistRectCameraMatrix_fisheye.fx(),
+                                       sf->getBaseline());
 
   // Test distortion with image comparison --> uncomment
   EXPECT_TRUE(UtilsOpenCV::compareCvMatsUpToTol(

--- a/tests/testStereoVisionFrontEnd.cpp
+++ b/tests/testStereoVisionFrontEnd.cpp
@@ -232,7 +232,7 @@ class StereoVisionFrontEndFixture : public ::testing::Test {
 
   std::vector<Point2> convertCornersAcrossCameras(
       const std::vector<Point2>& corners_in,
-      const Cal3DS2& calib_in,
+      const DistortionModel& calib_in,
       const Cal3_S2& calib_out) {
     CHECK_DOUBLE_EQ(calib_in.skew(), 0.0);
     CHECK_DOUBLE_EQ(calib_out.skew(), 0.0);
@@ -531,7 +531,7 @@ TEST_F(StereoVisionFrontEndFixture, DISABLED_processFirstFrame) {
       loadCorners(synthetic_stereo_path + "/corners_undistort_left.txt");
   std::vector<Point2> left_rect_corners =
       convertCornersAcrossCameras(left_undistort_corners,
-                                  sf.getLeftFrame().cam_param_.calibration_,
+                                  *(sf.getLeftFrame().cam_param_.distortion_),
                                   sf.getLeftUndistRectCamMat());
   for (int i = 0; i < num_corners; i++) {
     int idx_gt = corner_id_map_frame2gt[i];
@@ -546,7 +546,7 @@ TEST_F(StereoVisionFrontEndFixture, DISABLED_processFirstFrame) {
       loadCorners(synthetic_stereo_path + "/corners_undistort_right.txt");
   std::vector<Point2> right_rect_corners =
       convertCornersAcrossCameras(right_undistort_corners,
-                                  sf.getRightFrame().cam_param_.calibration_,
+                                  *(sf.getRightFrame().cam_param_.distortion_),
                                   sf.getRightUndistRectCamMat());
   for (int i = 0; i < num_corners; i++) {
     int idx_gt = corner_id_map_frame2gt[i];

--- a/tests/testTracker.cpp
+++ b/tests/testTracker.cpp
@@ -187,7 +187,7 @@ class TestTracker : public ::testing::Test {
           camRef_pose_camCur.inverse().translation();
       versor_cur = versor_cur / versor_cur.norm();
 
-      Point2 pt_cur_gtsam = f_ref->cam_param_.calibration_.uncalibrate(
+      Point2 pt_cur_gtsam = f_ref->cam_param_.distortion_->uncalibrate(
           Point2(versor_cur[0] / versor_cur[2], versor_cur[1] / versor_cur[2]));
       KeypointCV pt_cur(pt_cur_gtsam.x(), pt_cur_gtsam.y());
 
@@ -219,7 +219,7 @@ class TestTracker : public ::testing::Test {
           camRef_pose_camCur.inverse().translation();
       versor_cur = versor_cur / versor_cur.norm();
 
-      Point2 pt_cur_gtsam = f_ref->cam_param_.calibration_.uncalibrate(
+      Point2 pt_cur_gtsam = f_ref->cam_param_.distortion_->uncalibrate(
           Point2(versor_cur[0] / versor_cur[2], versor_cur[1] / versor_cur[2]));
       KeypointCV pt_cur(pt_cur_gtsam.x(), pt_cur_gtsam.y());
 


### PR DESCRIPTION
This PR contains:
- a more flexible model for GTSAM distortion support
- RadTan model with up to 8 coefficients: p1, p2, k1...k6
- Equidistant model with 4 coefficients

I tested with "testKimeraVIO", and got the following 3 failures that already fail in the master:
```
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] LCDFixture.detectLoop
[  FAILED  ] StereoFrameFixture.sparseStereoMatching
[  FAILED  ] TestTracker.getPoint3AndCovariance

```
