### PR TITLE
Correct rosdistro keys

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,11 +9,11 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>KimeraRPGO</depend>
-  <depend>GTSAM</depend>
+  <depend>kimera_rpgo</depend>
   <depend>gflags</depend>
   <depend>glog</depend>
-  <depend>opencv</depend>
+  <depend>gtsam</depend>
+  <depend>libopencv-dev</depend>
   <depend>opengv</depend>
   <depend>dbow2</depend>
   <export>
@@ -21,4 +21,3 @@
     <build_type>cmake</build_type>
   </export>
 </package>
-

--- a/package.xml
+++ b/package.xml
@@ -9,13 +9,13 @@
 
   <buildtool_depend>cmake</buildtool_depend>
 
-  <depend>kimera_rpgo</depend>
-  <depend>gflags</depend>
-  <depend>glog</depend>
+  <depend>dbow2</depend>
   <depend>gtsam</depend>
+  <depend>kimera_rpgo</depend>
+  <depend>libgflags-dev</depend>
+  <depend>libgoogle-glog-dev</depend>
   <depend>libopencv-dev</depend>
   <depend>opengv</depend>
-  <depend>dbow2</depend>
   <export>
     <!-- Specify that this is not really a catkin package-->
     <build_type>cmake</build_type>


### PR DESCRIPTION
This corrects the rosdistro key names so rosdep can properly resolve and install missing dependencies, as well fix some issues in finding exported headers from upstream projects.

See official list of rosdistro keys here:
https://github.com/ros/rosdistro/blob/master/rosdep/base.yaml

Related:
- https://github.com/borglab/gtsam/pull/173
- https://github.com/laurentkneip/opengv/pull/104
- https://github.com/dorian3d/DBoW2/pull/55
- https://github.com/opencv/opencv/pull/16322