### PR TITLE
Refactor loggers to allow for different output paths

### DIFF
--- a/examples/KimeraVIO.cpp
+++ b/examples/KimeraVIO.cpp
@@ -28,8 +28,10 @@
 #include "kimera-vio/utils/Statistics.h"
 #include "kimera-vio/utils/Timer.h"
 
-DEFINE_int32(dataset_type, 0, "Type of parser to use:\n "
-                              "0: Euroc \n 1: Kitti (not supported).");
+DEFINE_int32(dataset_type,
+             0,
+             "Type of parser to use:\n "
+             "0: Euroc \n 1: Kitti (not supported).");
 DEFINE_string(
     params_folder_path,
     "../params/Euroc",
@@ -86,14 +88,14 @@ int main(int argc, char* argv[]) {
   auto tic = VIO::utils::Timer::tic();
   bool is_pipeline_successful = false;
   if (vio_params.parallel_run_) {
-    auto handle = std::async(std::launch::async,
-                             &VIO::DataProviderInterface::spin,
-                             dataset_parser);
+    auto handle = std::async(
+        std::launch::async, &VIO::DataProviderInterface::spin, dataset_parser);
     auto handle_pipeline =
         std::async(std::launch::async, &VIO::Pipeline::spin, &vio_pipeline);
     auto handle_shutdown = std::async(std::launch::async,
                                       &VIO::Pipeline::shutdownWhenFinished,
-                                      &vio_pipeline, 500);
+                                      &vio_pipeline,
+                                      500);
     vio_pipeline.spinViz();
     is_pipeline_successful = !handle.get();
     handle_shutdown.get();
@@ -114,7 +116,7 @@ int main(int argc, char* argv[]) {
 
   if (is_pipeline_successful) {
     // Log overall time of pipeline run.
-    VIO::PipelineLogger logger;
+    VIO::PipelineLogger logger (vio_params.log_output_path_);
     logger.logPipelineOverallTiming(spin_duration);
   }
 

--- a/include/kimera-vio/backend/RegularVioBackEnd-definitions.h
+++ b/include/kimera-vio/backend/RegularVioBackEnd-definitions.h
@@ -14,25 +14,6 @@
 
 #pragma once
 
-#include <vector>
-
-#include <boost/optional.hpp>
-
-#include <glog/logging.h>
-
-#include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/StereoPoint2.h>
-#include <gtsam_unstable/nonlinear/IncrementalFixedLagSmoother.h>
-#include <gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h>
-
-#include "kimera-vio/common/vio_types.h"
-#include "kimera-vio/frontend/StereoVisionFrontEnd-definitions.h"
-#include "kimera-vio/frontend/Tracker-definitions.h"
-#include "kimera-vio/imu-frontend/ImuFrontEnd-definitions.h"
-#include "kimera-vio/imu-frontend/ImuFrontEnd.h"
-#include "kimera-vio/utils/Macros.h"
-#include "kimera-vio/utils/UtilsOpenCV.h"
-
 namespace VIO {
 
 enum class RegularBackendModality {

--- a/include/kimera-vio/backend/RegularVioBackEnd.h
+++ b/include/kimera-vio/backend/RegularVioBackEnd.h
@@ -36,7 +36,7 @@ class RegularVioBackEnd : public VioBackEnd {
                     const BackendParams& backend_params,
                     const ImuParams& imu_params,
                     const BackendOutputParams& backend_output_params,
-                    const bool& log_output);
+                    const std::string& log_output_path = "");
 
   virtual ~RegularVioBackEnd() = default;
 

--- a/include/kimera-vio/backend/VioBackEnd.h
+++ b/include/kimera-vio/backend/VioBackEnd.h
@@ -8,7 +8,11 @@
 
 /**
  * @file   VioBackEnd.h
- * @brief  Visual-Inertial Odometry pipeline, as described in these papers:
+ * @brief  Visual-Inertial backend, as described in these papers:
+ *
+ * A. Rosinol, M. Abate, Y. Chang, and L. Carlone.
+ * Kimera: an Open-Source Library for Real-Time Metric-Semantic Localization and
+ * Mapping. IEEE Intl. Conf. on Robotics and Automation (ICRA), 2020.
  *
  * C. Forster, L. Carlone, F. Dellaert, and D. Scaramuzza.
  * On-Manifold Preintegration Theory for Fast and Accurate Visual-Inertial
@@ -30,19 +34,11 @@
 #include <memory>
 #include <unordered_map>
 
-#include <boost/foreach.hpp>
-
-#include <gtsam/geometry/Cal3DS2.h>
 #include <gtsam/geometry/Cal3_S2.h>
-#include <gtsam/geometry/StereoCamera.h>
 #include <gtsam/geometry/StereoPoint2.h>
-#include <gtsam/navigation/CombinedImuFactor.h>
-#include <gtsam/navigation/ImuFactor.h>
 #include <gtsam/nonlinear/ISAM2.h>
 #include <gtsam/nonlinear/LinearContainerFactor.h>
-#include <gtsam/nonlinear/Marginals.h>
 #include <gtsam/nonlinear/NonlinearFactorGraph.h>
-#include <gtsam/slam/BetweenFactor.h>
 #include <gtsam/slam/PriorFactor.h>
 #include <gtsam_unstable/nonlinear/BatchFixedLagSmoother.h>
 #include <gtsam_unstable/slam/SmartStereoProjectionPoseFactor.h>
@@ -51,10 +47,9 @@
 #include "kimera-vio/backend/VioBackEndParams.h"
 #include "kimera-vio/factors/PointPlaneFactor.h"
 #include "kimera-vio/frontend/StereoVisionFrontEnd-definitions.h"
-#include "kimera-vio/imu-frontend/ImuFrontEnd.h"
+#include "kimera-vio/imu-frontend/ImuFrontEnd-definitions.h"
 #include "kimera-vio/logging/Logger.h"
 #include "kimera-vio/utils/Macros.h"
-#include "kimera-vio/utils/ThreadsafeQueue.h"
 #include "kimera-vio/utils/UtilsGTSAM.h"
 #include "kimera-vio/utils/UtilsOpenCV.h"
 
@@ -83,7 +78,7 @@ class VioBackEnd {
              const BackendParams& backend_params,
              const ImuParams& imu_params,
              const BackendOutputParams& backend_output_params,
-             bool log_output);
+             const std::string& log_output_path = "");
   virtual ~VioBackEnd() { LOG(INFO) << "Backend destructor called."; }
 
  public:
@@ -494,7 +489,6 @@ class VioBackEnd {
   size_t counter_of_exceptions_ = 0;
 
   //! Logger.
-  const bool log_output_ = {false};
   std::unique_ptr<BackendLogger> logger_;
 };
 

--- a/include/kimera-vio/backend/VioBackEndFactory.h
+++ b/include/kimera-vio/backend/VioBackEndFactory.h
@@ -29,31 +29,17 @@ class BackEndFactory {
   BackEndFactory() = delete;
   virtual ~BackEndFactory() = default;
 
-  static VioBackEnd::UniquePtr createBackend(
-      const BackendType& backend_type,
-      const Pose3& B_Pose_leftCam,
-      const StereoCalibPtr& stereo_calibration,
-      const BackendParams& backend_params,
-      const ImuParams& imu_params,
-      const BackendOutputParams& backend_output_params,
-      bool log_output) {
+ public:
+  template <typename... Ts>
+  static VioBackEnd::UniquePtr createBackend(const BackendType& backend_type,
+                                             Ts&&... args) {
     switch (backend_type) {
       case BackendType::kStereoImu: {
-        return VIO::make_unique<VioBackEnd>(B_Pose_leftCam,
-                                            stereo_calibration,
-                                            backend_params,
-                                            imu_params,
-                                            backend_output_params,
-                                            log_output);
-      }
+        return VIO::make_unique<VioBackEnd>(std::forward<Ts>(args)...);
+      } break;
       case BackendType::kStructuralRegularities: {
-        return VIO::make_unique<RegularVioBackEnd>(B_Pose_leftCam,
-                                                   stereo_calibration,
-                                                   backend_params,
-                                                   imu_params,
-                                                   backend_output_params,
-                                                   log_output);
-      }
+        return VIO::make_unique<RegularVioBackEnd>(std::forward<Ts>(args)...);
+      } break;
       default: {
         LOG(FATAL) << "Requested backend type is not supported.\n"
                    << "Currently supported backend types:\n"

--- a/include/kimera-vio/dataprovider/DataProviderModule.h
+++ b/include/kimera-vio/dataprovider/DataProviderModule.h
@@ -26,6 +26,7 @@
 
 #include <glog/logging.h>
 
+#include "kimera-vio/imu-frontend/ImuData.h"
 #include "kimera-vio/frontend/StereoImuSyncPacket.h"
 #include "kimera-vio/frontend/StereoMatchingParams.h"
 #include "kimera-vio/pipeline/Pipeline-definitions.h"

--- a/include/kimera-vio/dataprovider/KittiDataProvider.h
+++ b/include/kimera-vio/dataprovider/KittiDataProvider.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <string>
 
+#include "kimera-vio/imu-frontend/ImuData.h"
 #include "kimera-vio/dataprovider/DataProviderInterface.h"
 #include "kimera-vio/frontend/StereoImuSyncPacket.h"
 

--- a/include/kimera-vio/frontend/StereoVisionFrontEnd.h
+++ b/include/kimera-vio/frontend/StereoVisionFrontEnd.h
@@ -58,7 +58,7 @@ class StereoVisionFrontEnd {
                        const FrontendParams& tracker_params,
                        const CameraParams& camera_params,
                        DisplayQueue* display_queue = nullptr,
-                       bool log_output = false);
+                       const std::string& log_output_path = "");
   virtual ~StereoVisionFrontEnd() {
     LOG(INFO) << "StereoVisionFrontEnd destructor called.";
   }

--- a/include/kimera-vio/frontend/VisionFrontEndFactory.h
+++ b/include/kimera-vio/frontend/VisionFrontEndFactory.h
@@ -27,14 +27,24 @@ class VisionFrontEndFactory {
   VisionFrontEndFactory() = delete;
   virtual ~VisionFrontEndFactory() = default;
 
+  template <typename... Ts>
   static StereoVisionFrontEnd::UniquePtr createFrontend(
       const FrontendType& frontend_type,
-      const ImuParams& imu_params,
-      const ImuBias& imu_initial_bias,
-      const FrontendParams& frontend_params,
-      const CameraParams& camera_params,
-      DisplayQueue* display_queue,
-      bool log_output);
+      Ts&&... args) {
+    switch (frontend_type) {
+      case FrontendType::kStereoImu: {
+        return VIO::make_unique<StereoVisionFrontEnd>(
+            std::forward<Ts>(args)...);
+      }
+      default: {
+        LOG(FATAL) << "Requested fronetnd type is not supported.\n"
+                   << "Currently supported frontend types:\n"
+                   << "0: Stereo + IMU \n"
+                   << " but requested frontend: "
+                   << static_cast<int>(frontend_type);
+      }
+    }
+  }
 };
 
 }  // namespace VIO

--- a/include/kimera-vio/imu-frontend/CMakeLists.txt
+++ b/include/kimera-vio/imu-frontend/CMakeLists.txt
@@ -1,6 +1,7 @@
 ### Add source code for kimera_vio
 target_sources(kimera_vio PRIVATE
   "${CMAKE_CURRENT_LIST_DIR}/ImuFrontEnd-definitions.h"
+  "${CMAKE_CURRENT_LIST_DIR}/ImuData.h"
   "${CMAKE_CURRENT_LIST_DIR}/ImuFrontEnd.h"
   "${CMAKE_CURRENT_LIST_DIR}/ImuFrontEndParams.h"
 )

--- a/include/kimera-vio/imu-frontend/ImuData.h
+++ b/include/kimera-vio/imu-frontend/ImuData.h
@@ -1,0 +1,44 @@
+/* ----------------------------------------------------------------------------
+ * Copyright 2017, Massachusetts Institute of Technology,
+ * Cambridge, MA 02139
+ * All Rights Reserved
+ * Authors: Luca Carlone, et al. (see THANKS for the full author list)
+ * See LICENSE for the license information
+ * -------------------------------------------------------------------------- */
+
+/**
+ * @file   ImuData.h
+ * @brief  Container for IMU data
+ * @author Antoni Rosinol
+ */
+
+#pragma once
+
+#include "kimera-vio/utils/Macros.h"
+#include "kimera-vio/utils/ThreadsafeImuBuffer.h"
+
+namespace VIO {
+
+/**
+ * @brief The ImuData class Contains inertial measurements in a temporal buffer
+ * that is threadsafe.
+ */
+class ImuData {
+ public:
+  KIMERA_POINTER_TYPEDEFS(ImuData);
+  KIMERA_DELETE_COPY_CONSTRUCTORS(ImuData);
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  //! Imu buffer with virtually infinite memory.
+  ImuData() : imu_buffer_(-1) {}
+  ~ImuData() = default;
+
+ public:
+  void print() const;
+
+ public:
+  //! Imu data.
+  utils::ThreadsafeImuBuffer imu_buffer_;
+};
+
+}  // namespace VIO

--- a/include/kimera-vio/imu-frontend/ImuFrontEnd-definitions.h
+++ b/include/kimera-vio/imu-frontend/ImuFrontEnd-definitions.h
@@ -38,6 +38,9 @@ using ImuGyr = Eigen::Matrix<double, 3, 1>;
 using ImuAccGyrS = Eigen::Matrix<double, 6, Eigen::Dynamic>;
 using ImuBias = gtsam::imuBias::ConstantBias;
 
+/**
+ * @brief The ImuMeasurement struct One single IMU measurement
+ */
 struct ImuMeasurement {
   ImuMeasurement() = default;
   ImuMeasurement(const ImuStamp& timestamp, const ImuAccGyr& imu_data)
@@ -50,7 +53,10 @@ struct ImuMeasurement {
   ImuAccGyr acc_gyr_;
 };
 
-// Multiple Imu measurements, bundled in dynamic matrices.
+/**
+ * @brief The ImuMeasurements struct Multiple Imu measurements, bundled in
+ * dynamic matrices.
+ */
 struct ImuMeasurements {
  public:
   ImuMeasurements() = default;
@@ -64,6 +70,9 @@ struct ImuMeasurements {
   ImuAccGyrS acc_gyr_;
 };
 
+/**
+ * @brief The ImuPreintegrationType enum Types of supported IMU preintegration.
+ */
 enum class ImuPreintegrationType {
   kPreintegratedCombinedMeasurements = 0,
   kPreintegratedImuMeasurements = 1

--- a/include/kimera-vio/imu-frontend/ImuFrontEnd.h
+++ b/include/kimera-vio/imu-frontend/ImuFrontEnd.h
@@ -15,52 +15,25 @@
 #pragma once
 
 #include <map>
-#include <string>
-#include <tuple>
-#include <thread>
-#include <utility>
 #include <mutex>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <utility>
 
 #include <Eigen/Dense>
 
 #include <gtsam/base/Matrix.h>
 #include <gtsam/base/Vector.h>
-#include <gtsam/navigation/AHRSFactor.h>
-#include <gtsam/navigation/CombinedImuFactor.h>  // Used if IMU combined is off.
-#include <gtsam/navigation/ImuBias.h>
-#include <gtsam/navigation/ImuFactor.h>
 
 #include "kimera-vio/imu-frontend/ImuFrontEnd-definitions.h"
 #include "kimera-vio/imu-frontend/ImuFrontEndParams.h"
 #include "kimera-vio/utils/Macros.h"
-#include "kimera-vio/utils/ThreadsafeImuBuffer.h"
 
 namespace VIO {
 
-class ImuData {
-public:
- KIMERA_POINTER_TYPEDEFS(ImuData);
- KIMERA_DELETE_COPY_CONSTRUCTORS(ImuData);
- EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
- // Imu buffer with virtually infinite memory.
- ImuData() : imu_buffer_(-1) {}
-
- // Checks for statistics..
- // TODO(Toni): remove these and put in params.
- double imu_rate_;
- double nominal_imu_rate_;
- double imu_rate_std_;
- double imu_rate_maxMismatch_;
-
- // Imu data.
- utils::ThreadsafeImuBuffer imu_buffer_;
-
-public:
-  void print() const;
-};
-
-/*
+/**
+ * @brief The ImuFrontEnd class
  * Class implementing the Imu Front End preintegration.
  * Construct using imu_params, and optionally an initial ImuBias.
  * Call preintegrateImuMeasurements to progressively integrate a bunch of Imu
@@ -69,65 +42,69 @@ public:
  * the Imu bias.
  */
 class ImuFrontEnd {
-public:
- using PimPtr = std::shared_ptr<gtsam::PreintegrationType>;
- using PimUniquePtr = std::unique_ptr<gtsam::PreintegrationType>;
+ public:
+  using PimPtr = std::shared_ptr<gtsam::PreintegrationType>;
+  using PimUniquePtr = std::unique_ptr<gtsam::PreintegrationType>;
 
-public:
- KIMERA_POINTER_TYPEDEFS(ImuFrontEnd);
- KIMERA_DELETE_COPY_CONSTRUCTORS(ImuFrontEnd);
- EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+ public:
+  KIMERA_POINTER_TYPEDEFS(ImuFrontEnd);
+  KIMERA_DELETE_COPY_CONSTRUCTORS(ImuFrontEnd);
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
- /* ------------------------------------------------------------------------
-  * Class to do IMU preintegration.
-  * [in] imu_params: IMU parameters used for the preintegration.
-  * [in] imu_bias: IMU bias used to initialize PreintegratedImuMeasurements
-  * !! The user of this class must update the bias and reset the integration
-  * manually in order to preintegrate the IMU with the latest IMU bias coming
-  * from the backend optimization.
-  */
- ImuFrontEnd(const ImuParams& imu_params, const ImuBias& imu_bias);
- ~ImuFrontEnd() = default;
+  /* ------------------------------------------------------------------------
+   * Class to do IMU preintegration.
+   * [in] imu_params: IMU parameters used for the preintegration.
+   * [in] imu_bias: IMU bias used to initialize PreintegratedImuMeasurements
+   * !! The user of this class must update the bias and reset the integration
+   * manually in order to preintegrate the IMU with the latest IMU bias coming
+   * from the backend optimization.
+   */
+  ImuFrontEnd(const ImuParams& imu_params, const ImuBias& imu_bias);
+  virtual ~ImuFrontEnd() = default;
 
- /* ------------------------------------------------------------------------ */
- PimPtr preintegrateImuMeasurements(const ImuStampS& imu_stamps,
-                                    const ImuAccGyrS& imu_accgyr);
- PimPtr preintegrateImuMeasurements(const ImuStampS& imu_stamps,
-                                    const ImuAccGyr& imu_accgyr) = delete;
- PimPtr preintegrateImuMeasurements(const ImuStamp& imu_stamps,
-                                    const ImuAccGyrS& imu_accgyr) = delete;
- PimPtr preintegrateImuMeasurements(const ImuStamp& imu_stamps,
-                                    const ImuAccGyr& imu_accgyr) = delete;
+  /* ------------------------------------------------------------------------ */
+  PimPtr preintegrateImuMeasurements(const ImuStampS& imu_stamps,
+                                     const ImuAccGyrS& imu_accgyr);
+  // Delete dangerous misspellings
+  PimPtr preintegrateImuMeasurements(const ImuStampS& imu_stamps,
+                                     const ImuAccGyr& imu_accgyr) = delete;
+  PimPtr preintegrateImuMeasurements(const ImuStamp& imu_stamps,
+                                     const ImuAccGyrS& imu_accgyr) = delete;
+  PimPtr preintegrateImuMeasurements(const ImuStamp& imu_stamps,
+                                     const ImuAccGyr& imu_accgyr) = delete;
 
- /* ------------------------------------------------------------------------- */
- gtsam::Rot3 preintegrateGyroMeasurements(const ImuStampS& imu_stamps,
-                                          const ImuAccGyrS& imu_accgyr);
- gtsam::Rot3 preintegrateGyroMeasurements(const ImuStampS& imu_stamps,
-                                          const ImuAccGyr& imu_accgyr) = delete;
- gtsam::Rot3 preintegrateGyroMeasurements(const ImuStamp& imu_stamps,
-                                          const ImuAccGyrS& imu_accgyr) =
-     delete;
- gtsam::Rot3 preintegrateGyroMeasurements(const ImuStamp& imu_stamps,
-                                          const ImuAccGyr& imu_accgyr) = delete;
+  /* ------------------------------------------------------------------------ */
+  gtsam::Rot3 preintegrateGyroMeasurements(const ImuStampS& imu_stamps,
+                                           const ImuAccGyrS& imu_accgyr);
+  // Delete dangerous misspellings
+  gtsam::Rot3 preintegrateGyroMeasurements(const ImuStampS& imu_stamps,
+                                           const ImuAccGyr& imu_accgyr) =
+      delete;
+  gtsam::Rot3 preintegrateGyroMeasurements(const ImuStamp& imu_stamps,
+                                           const ImuAccGyrS& imu_accgyr) =
+      delete;
+  gtsam::Rot3 preintegrateGyroMeasurements(const ImuStamp& imu_stamps,
+                                           const ImuAccGyr& imu_accgyr) =
+      delete;
 
- /* ------------------------------------------------------------------------ */
- // This should be called by the backend, whenever there
- // is a new imu bias estimate. Note that we only store the new
- // bias, but we don't reset the pre-integration.This is because we
- // might have already started preintegrating measurements from
- // latest keyframe to the current frame using the previous bias,
- // which at the moment was the best last estimate.
- // The pre-integration is updated with the correct bias
- // in the backend.
- inline void updateBias(const ImuBias& imu_bias_prev_kf) {
-   std::lock_guard<std::mutex> lock(imu_bias_mutex_);
-   latest_imu_bias_ = imu_bias_prev_kf;
-   // Debug output.
-   if (VLOG_IS_ON(10)) {
-     LOG(INFO) << "Updating Preintegration imu bias (needs to reset "
-                  "integration for the bias to have effect):";
-     latest_imu_bias_.print();
-   }
+  /* ------------------------------------------------------------------------ */
+  // This should be called by the backend, whenever there
+  // is a new imu bias estimate. Note that we only store the new
+  // bias, but we don't reset the pre-integration.This is because we
+  // might have already started preintegrating measurements from
+  // latest keyframe to the current frame using the previous bias,
+  // which at the moment was the best last estimate.
+  // The pre-integration is updated with the correct bias
+  // in the backend.
+  inline void updateBias(const ImuBias& imu_bias_prev_kf) {
+    std::lock_guard<std::mutex> lock(imu_bias_mutex_);
+    latest_imu_bias_ = imu_bias_prev_kf;
+    // Debug output.
+    if (VLOG_IS_ON(10)) {
+      LOG(INFO) << "Updating Preintegration imu bias (needs to reset "
+                   "integration for the bias to have effect):";
+      latest_imu_bias_.print();
+    }
   }
 
   /* ------------------------------------------------------------------------ */
@@ -204,4 +181,4 @@ public:
   mutable std::mutex imu_bias_mutex_;
 };
 
-} // End of VIO namespace.
+}  // End of VIO namespace.

--- a/include/kimera-vio/initial/InitializationBackEnd.h
+++ b/include/kimera-vio/initial/InitializationBackEnd.h
@@ -40,7 +40,7 @@ class InitializationBackEnd : public VioBackEnd {
                         const BackendParams& backend_params,
                         const ImuParams& imu_params,
                         const BackendOutputParams& backend_output_params,
-                        const bool log_output = false);
+                        const std::string& log_output_path = "");
 
   /* ------------------------------------------------------------------------ */
   virtual ~InitializationBackEnd() {

--- a/include/kimera-vio/logging/Logger.h
+++ b/include/kimera-vio/logging/Logger.h
@@ -44,16 +44,17 @@ class OfstreamWrapper {
  public:
   KIMERA_POINTER_TYPEDEFS(OfstreamWrapper);
   KIMERA_DELETE_COPY_CONSTRUCTORS(OfstreamWrapper);
-  OfstreamWrapper(const std::string& filename,
+  OfstreamWrapper(const std::string& output_path,
+                  const std::string& filename,
                   const bool& open_file_in_append_mode = false);
   virtual ~OfstreamWrapper();
   void closeAndOpenLogFile();
 
  public:
   std::ofstream ofstream_;
-  const std::string filename_;
   const std::string output_path_;
-  const bool open_file_in_append_mode = false;
+  const std::string filename_;
+  const bool open_file_in_append_mode_ = false;
 
  protected:
   void openLogFile(const std::string& output_file_name,
@@ -61,14 +62,29 @@ class OfstreamWrapper {
 };
 
 /**
+ * @brief The Logger class: all loggers shall inherit from this class so that
+ * the output log path directory is correctly and coherently set.
+ */
+class Logger {
+ public:
+  KIMERA_POINTER_TYPEDEFS(Logger);
+  KIMERA_DELETE_COPY_CONSTRUCTORS(Logger);
+  explicit Logger(const std::string& output_path);
+  virtual ~Logger() = default;
+
+ public:
+  std::string output_path_;
+};
+
+/**
  * @brief Logs ground-truth info from Euroc dataset, just copy-paste
  * ground-truth csv file.
  */
-class EurocGtLogger {
+class EurocGtLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(EurocGtLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(EurocGtLogger);
-  EurocGtLogger();
+  EurocGtLogger(const std::string& output_path);
   virtual ~EurocGtLogger() = default;
 
   /**
@@ -84,11 +100,11 @@ class EurocGtLogger {
   OfstreamWrapper output_gt_poses_csv_;
 };
 
-class BackendLogger {
+class BackendLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(BackendLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(BackendLogger);
-  BackendLogger();
+  BackendLogger(const std::string& output_path);
   virtual ~BackendLogger() = default;
 
   void logBackendOutput(const BackendOutput& output);
@@ -122,11 +138,11 @@ class BackendLogger {
   bool is_header_written_backend_timing_ = false;
 };
 
-class FrontendLogger {
+class FrontendLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(FrontendLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(FrontendLogger);
-  FrontendLogger();
+  FrontendLogger(const std::string& output_path);
   virtual ~FrontendLogger() = default;
 
   void logFrontendStats(const Timestamp& timestamp_lkf,
@@ -154,11 +170,11 @@ class FrontendLogger {
   bool is_header_written_ransac_stereo_ = false;
 };
 
-class MesherLogger {
+class MesherLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(MesherLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(MesherLogger);
-  MesherLogger();
+  MesherLogger(const std::string& output_path);
   virtual ~MesherLogger() = default;
 
   /**
@@ -188,15 +204,14 @@ class MesherLogger {
   }
 
  protected:
-  std::string output_path_;
   bool is_header_written_ = false;
 };
 
-class VisualizerLogger {
+class VisualizerLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(VisualizerLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(VisualizerLogger);
-  VisualizerLogger();
+  VisualizerLogger(const std::string& output_path);
   virtual ~VisualizerLogger() = default;
 
   void logLandmarks(const PointsWithId& lmks);
@@ -222,11 +237,11 @@ class VisualizerLogger {
   bool is_header_written_mesh_ = false;
 };
 
-class PipelineLogger {
+class PipelineLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(PipelineLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(PipelineLogger);
-  PipelineLogger();
+  PipelineLogger(const std::string& output_path);
   virtual ~PipelineLogger() = default;
 
   void logPipelineOverallTiming(const std::chrono::milliseconds& duration);
@@ -236,11 +251,11 @@ class PipelineLogger {
   OfstreamWrapper output_pipeline_timing_;
 };
 
-class LoopClosureDetectorLogger {
+class LoopClosureDetectorLogger : public Logger {
  public:
   KIMERA_POINTER_TYPEDEFS(LoopClosureDetectorLogger);
   KIMERA_DELETE_COPY_CONSTRUCTORS(LoopClosureDetectorLogger);
-  LoopClosureDetectorLogger();
+  LoopClosureDetectorLogger(const std::string& output_path);
   virtual ~LoopClosureDetectorLogger() = default;
 
   void logTimestampMap(

--- a/include/kimera-vio/mesh/Mesher-definitions.h
+++ b/include/kimera-vio/mesh/Mesher-definitions.h
@@ -63,15 +63,21 @@ struct MesherParams {
   KIMERA_POINTER_TYPEDEFS(MesherParams);
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   MesherParams() = default;
-  MesherParams(const gtsam::Pose3& B_Pose_camLrect, const cv::Size& img_size)
-      : B_Pose_camLrect_(B_Pose_camLrect), img_size_(img_size) {}
-  ~MesherParams() = default;
+  MesherParams(const gtsam::Pose3& B_Pose_camLrect,
+               const cv::Size& img_size,
+               const std::string& log_output_path = "")
+      : B_Pose_camLrect_(B_Pose_camLrect),
+        img_size_(img_size),
+        log_output_path_(log_output_path){}
+  virtual ~MesherParams() = default;
 
  public:
   //! B_Pose_camLrect pose of the rectified camera wrt body frame of ref.
   gtsam::Pose3 B_Pose_camLrect_;
   //! img_size size of the camera's images used for 2D triangulation.
   cv::Size img_size_;
+  //! Path where to log mesher output
+  std::string log_output_path_ = "";
 };
 
 struct MesherInput : public PipelinePayload {

--- a/include/kimera-vio/mesh/MesherFactory.h
+++ b/include/kimera-vio/mesh/MesherFactory.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include "kimera-vio/mesh/Mesher-definitions.h"
 #include "kimera-vio/mesh/Mesher.h"
 #include "kimera-vio/utils/Macros.h"
@@ -26,8 +28,24 @@ class MesherFactory {
   KIMERA_DELETE_COPY_CONSTRUCTORS(MesherFactory);
   MesherFactory() = delete;
   virtual ~MesherFactory() = default;
-  static Mesher::UniquePtr createMesher(const MesherType& mesher_type,
-                                        const MesherParams& mesher_params);
+
+ public:
+  template <typename... Ts>
+  static Mesher::UniquePtr createMesher(
+      const MesherType& mesher_type,
+      Ts&&... args) {
+    switch (mesher_type) {
+      case MesherType::PROJECTIVE: {
+        static constexpr bool kSerializeMesh2d3d = false;
+        return VIO::make_unique<Mesher>(std::forward<Ts>(args)...,
+                                        kSerializeMesh2d3d);
+      }
+      default: {
+        LOG(FATAL) << "Requested mesher type is not supported.\n"
+                   << static_cast<int>(mesher_type);
+      }
+    }
+  }
 };
 
 }  // namespace VIO

--- a/include/kimera-vio/pipeline/Pipeline-definitions.h
+++ b/include/kimera-vio/pipeline/Pipeline-definitions.h
@@ -118,6 +118,9 @@ struct VioParams : public PipelineParams {
   FrontendType frontend_type_;
   BackendType backend_type_;
   bool parallel_run_;
+  //! Log output path where to store VIO's output in CSV files.
+  //! If empty, no output log will be generated.
+  std::string log_output_path_;
 
  protected:
   //! Helper function to parse camera params.
@@ -132,9 +135,9 @@ struct VioParams : public PipelineParams {
         lcd_params_ == rhs.lcd_params_ &&
         frontend_type_ == rhs.frontend_type_ &&
         backend_type_ == rhs.backend_type_ &&
-        parallel_run_ == rhs.parallel_run_;
+        parallel_run_ == rhs.parallel_run_ &&
+        log_output_path_ == rhs.log_output_path_;
   }
-
 
   //! Names of the YAML files with the parameters.
   std::string pipeline_params_filename_;

--- a/include/kimera-vio/pipeline/Pipeline.h
+++ b/include/kimera-vio/pipeline/Pipeline.h
@@ -237,15 +237,12 @@ class Pipeline {
     is_backend_ok_ = false;
   }
 
-  // VIO parameters
-  BackendParams::ConstPtr backend_params_;
-  FrontendParams frontend_params_;
-  ImuParams imu_params_;
-  BackendType backend_type_;
-  bool parallel_run_;
+ public:
+  //! VIO parameters
+  VioParams vio_params_;
 
-  // TODO(Toni): Remove this?
-  int init_frame_id_;
+  //! TODO(TONI): remove this
+  FrameId init_frame_id_;
 
   //! Definition of sensor rig used
   StereoCamera::UniquePtr stereo_camera_;

--- a/include/kimera-vio/visualizer/Visualizer3D.h
+++ b/include/kimera-vio/visualizer/Visualizer3D.h
@@ -53,8 +53,9 @@ class Visualizer3D {
    * @param backend_type backend used so that we display the right info
    */
   Visualizer3D(const VisualizationType& viz_type,
-               const BackendType& backend_type);
-  virtual ~Visualizer3D() { LOG(INFO) << "Visualizer3D destructor"; };
+               const BackendType& backend_type,
+               const std::string& log_output_path);
+  virtual ~Visualizer3D() { LOG(INFO) << "Visualizer3D destructor"; }
 
   /* ------------------------------------------------------------------------ */
   inline void registerMesh3dVizProperties(

--- a/include/kimera-vio/visualizer/Visualizer3DFactory.h
+++ b/include/kimera-vio/visualizer/Visualizer3DFactory.h
@@ -30,10 +30,24 @@ class VisualizerFactory {
   VisualizerFactory() = delete;
   virtual ~VisualizerFactory() = default;
 
+ public:
+  template <typename... Ts>
   static Visualizer3D::UniquePtr createVisualizer(
-      const VisualizerType visualizer_type,
-      const VisualizationType& viz_type,
-      const BackendType& backend_type);
+      const VisualizerType& visualizer_type,
+      Ts&&... args) {
+    switch (visualizer_type) {
+      case VisualizerType::OpenCV: {
+        return VIO::make_unique<Visualizer3D>(std::forward<Ts>(args)...);
+      }
+      default: {
+        LOG(FATAL) << "Requested visualizer type is not supported.\n"
+                   << "Currently supported visualizer types:\n"
+                   << "0: OpenCV 3D viz\n 1: Pangolin (not supported yet)\n"
+                   << " but requested visualizer: "
+                   << static_cast<int>(visualizer_type);
+      }
+    }
+  }
 };
 
 }  // namespace VIO

--- a/params/Euroc/BackendParams.yaml
+++ b/params/Euroc/BackendParams.yaml
@@ -12,7 +12,7 @@ imuIntegrationSigma: 1.0e-8
 n_gravity: [0.0, 0.0, -9.81]
 nominalImuRate: 0.005
 #INITIALIZATION PARAMETERS
-autoInitialize: 0
+autoInitialize: 1
 roundOnAutoInitialize: 0
 initialPositionSigma: 1e-05
 initialRollPitchSigma: 0.174533 # 10.0/180.0*M_PI

--- a/params/Tesse/BackendParams.yaml
+++ b/params/Tesse/BackendParams.yaml
@@ -66,7 +66,7 @@ noMotionPositionSigma: 0.001
 noMotionRotationSigma: 0.0001
 constantVelSigma: 0.01
 numOptimize: 1
-horizon: 5 # In seconds.
+horizon: 20 # In seconds.
 # ISAM2GaussNewtonParams: continue updating the linear delta only when
 # changes are above this threshold (default: 0.001)
 wildfire_threshold: 0.001

--- a/params/Tesse/FrontendParams.yaml
+++ b/params/Tesse/FrontendParams.yaml
@@ -4,7 +4,7 @@ klt_win_size: 24
 klt_max_iter: 30
 klt_max_level: 4
 klt_eps: 0.1
-maxFeatureAge: 15
+maxFeatureAge: 1000
 
 # Detector Params
 # 0: FAST
@@ -71,4 +71,4 @@ disparityThreshold: 0.5
 # Type of optical flow predictor to aid feature tracking:
 # 0: Static - assumes no optical flow between images (aka static camera).
 # 1: Rotational - use IMU gyro to estimate optical flow.
-optical_flow_predictor_type: 1
+optical_flow_predictor_type: 0

--- a/scripts/stereoVIOEuroc.bash
+++ b/scripts/stereoVIOEuroc.bash
@@ -12,8 +12,6 @@ DATASET_TYPE=0
 # Specify: 1 to enable the LoopClosureDetector, 0 to not.
 USE_LCD=0
 
-# Specify: 1 to enable logging of output files, 0 to not.
-LOG_OUTPUT=0
 ###################################################################
 
 ###################################################################
@@ -30,8 +28,8 @@ PARAMS_PATH="../params/Euroc"
 VOCABULARY_PATH="../vocabulary"
 
 # Output path: specify where the output logs will be written.
-# (only used if LOG_OUTPUT is enabled)
-OUTPUT_PATH="../output_logs"
+# (not used if empty)
+OUTPUT_PATH=""
 ###################################################################
 
 # Parse Options.
@@ -53,8 +51,6 @@ else
           shift ;;
       -lcd) USE_LCD=1
            echo "Run VIO with LoopClosureDetector!" ;;
-      -log) LOG_OUTPUT=1
-           echo "Logging output!";;
       --)
           shift # The double dash which separates options from parameters
           break
@@ -102,14 +98,11 @@ $BUILD_PATH/stereoVIOEuroc \
   --log_prefix=1 \
   --v=0 \
   --vmodule=Pipeline*=00 \
-  --log_output="$LOG_OUTPUT" \
-  --log_euroc_gt_data="$LOG_OUTPUT" \
   --save_frontend_images=1 \
   --visualize_frontend_images=1 \
-  --output_path="$OUTPUT_PATH"
 
 # If in debug mode, you can run gdb to trace problems.
 #export PARAMS_PATH=../params/Euroc
 #export DATASET_PATH=/home/tonirv/datasets/EuRoC/V1_01_easy
-#gdb --args ../build/stereoVIOEuroc --flagfile="$PARAMS_PATH/flags/stereoVIOEuroc.flags" --flagfile="$PARAMS_PATH/flags/Mesher.flags" --flagfile="$PARAMS_PATH/flags/VioBackEnd.flags" --flagfile="$PARAMS_PATH/flags/RegularVioBackEnd.flags" --flagfile="$PARAMS_PATH/flags/Visualizer3D.flags" --logtostderr=1 --colorlogtostderr=1 --log_prefix=0 --dataset_path="$DATASET_PATH" --params_folder_path="$PARAMS_PATH" --initial_k=50 --final_k=2000 --vocabulary_path="../vocabulary/ORBvoc.yml" --use_lcd="0" --v=0 --vmodule=VioBackEnd=0 --dataset_type="0" --log_output="0" --output_path="../output_logs/"
+#gdb --args ../build/stereoVIOEuroc --flagfile="$PARAMS_PATH/flags/stereoVIOEuroc.flags" --flagfile="$PARAMS_PATH/flags/Mesher.flags" --flagfile="$PARAMS_PATH/flags/VioBackEnd.flags" --flagfile="$PARAMS_PATH/flags/RegularVioBackEnd.flags" --flagfile="$PARAMS_PATH/flags/Visualizer3D.flags" --logtostderr=1 --colorlogtostderr=1 --log_prefix=0 --dataset_path="$DATASET_PATH" --params_folder_path="$PARAMS_PATH" --initial_k=50 --final_k=2000 --vocabulary_path="../vocabulary/ORBvoc.yml" --use_lcd="0" --v=0 --vmodule=VioBackEnd=0 --dataset_type="0"
 

--- a/src/backend/RegularVioBackEnd.cpp
+++ b/src/backend/RegularVioBackEnd.cpp
@@ -103,14 +103,14 @@ RegularVioBackEnd::RegularVioBackEnd(
     const BackendParams& backend_params,
     const ImuParams& imu_params,
     const BackendOutputParams& backend_output_params,
-    const bool& log_output)
+    const std::string& log_output_path)
     : regular_vio_params_(RegularVioBackEndParams::safeCast(backend_params)),
       VioBackEnd(B_Pose_leftCam,
                  stereo_calibration,
                  backend_params,
                  imu_params,
                  backend_output_params,
-                 log_output) {
+                 log_output_path) {
   LOG(INFO) << "Using Regular VIO backend.\n";
 
   // Set type of mono_noise_ for generic projection factors.

--- a/src/dataprovider/EurocDataProvider.cpp
+++ b/src/dataprovider/EurocDataProvider.cpp
@@ -40,9 +40,6 @@ DEFINE_int64(final_k,
              10000,
              "Final frame to finish processing dataset, "
              "subsequent frames will not be used.");
-DEFINE_bool(log_euroc_gt_data,
-            false,
-            "Log Euroc ground-truth data to file for later evaluation.");
 
 namespace VIO {
 
@@ -57,8 +54,10 @@ EurocDataProvider::EurocDataProvider(const std::string& dataset_path,
       initial_k_(initial_k),
       final_k_(final_k),
       pipeline_params_(vio_params),
-      logger_(FLAGS_log_euroc_gt_data ? VIO::make_unique<EurocGtLogger>()
-                                      : nullptr) {
+      logger_(nullptr) {
+  if (!vio_params.log_output_path_.empty()) {
+    logger_ = VIO::make_unique<EurocGtLogger>(vio_params.log_output_path_);
+  }
   // Start processing dataset from frame initial_k.
   // Useful to skip a bunch of images at the beginning (imu calibration).
   CHECK_GE(initial_k_, 0);

--- a/src/frontend/StereoVisionFrontEnd.cpp
+++ b/src/frontend/StereoVisionFrontEnd.cpp
@@ -48,7 +48,7 @@ StereoVisionFrontEnd::StereoVisionFrontEnd(
     const FrontendParams& frontend_params,
     const CameraParams& camera_params,
     DisplayQueue* display_queue,
-    bool log_output)
+    const std::string& log_output_path)
     : stereoFrame_k_(nullptr),
       stereoFrame_km1_(nullptr),
       stereoFrame_lkf_(nullptr),
@@ -61,8 +61,8 @@ StereoVisionFrontEnd::StereoVisionFrontEnd(
       output_images_path_("./outputImages/"),
       display_queue_(display_queue),
       logger_(nullptr) {  // Only for debugging and visualization.
-  if (log_output) {
-    logger_ = VIO::make_unique<FrontendLogger>();
+  if (!log_output_path.empty()) {
+    logger_ = VIO::make_unique<FrontendLogger>(log_output_path);
   }
 
   // Instantiate FeatureDetector

--- a/src/frontend/VisionFrontEndFactory.cpp
+++ b/src/frontend/VisionFrontEndFactory.cpp
@@ -14,35 +14,6 @@
 
 #include "kimera-vio/frontend/VisionFrontEndFactory.h"
 
-#include <glog/logging.h>
-
 namespace VIO {
-
-StereoVisionFrontEnd::UniquePtr VisionFrontEndFactory::createFrontend(
-    const FrontendType& frontend_type,
-    const ImuParams& imu_params,
-    const ImuBias& imu_initial_bias,
-    const FrontendParams& frontend_params,
-    const CameraParams& camera_params,
-    DisplayQueue* display_queue,
-    bool log_output) {
-  switch (frontend_type) {
-    case FrontendType::kStereoImu: {
-      return VIO::make_unique<StereoVisionFrontEnd>(imu_params,
-                                                    imu_initial_bias,
-                                                    frontend_params,
-                                                    camera_params,
-                                                    display_queue,
-                                                    log_output);
-    }
-    default: {
-      LOG(FATAL) << "Requested fronetnd type is not supported.\n"
-                 << "Currently supported frontend types:\n"
-                 << "0: Stereo + IMU \n"
-                 << " but requested frontend: "
-                 << static_cast<int>(frontend_type);
-    }
-  }
-}
 
 }  // namespace VIO

--- a/src/imu-frontend/CMakeLists.txt
+++ b/src/imu-frontend/CMakeLists.txt
@@ -1,6 +1,7 @@
 ### Add source code for kimera_vio
 target_sources(kimera_vio
     PRIVATE
+      "${CMAKE_CURRENT_LIST_DIR}/ImuData.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/ImuFrontEnd.cpp"
       "${CMAKE_CURRENT_LIST_DIR}/ImuFrontEndParams.cpp"
 )

--- a/src/imu-frontend/ImuData.cpp
+++ b/src/imu-frontend/ImuData.cpp
@@ -7,14 +7,20 @@
  * -------------------------------------------------------------------------- */
 
 /**
- * @file   MesherFactory.h
- * @brief  Build a Mesher
+ * @file   ImuData.cpp
+ * @brief  Class to store Inertial data
  * @author Antoni Rosinol
  */
 
-#include "kimera-vio/mesh/MesherFactory.h"
+#include "kimera-vio/imu-frontend/ImuData.h"
+
+#include <glog/logging.h>
 
 namespace VIO {
 
+void ImuData::print() const {
+  LOG(INFO) << "------------ ImuData::print -------------\n"
+            << "Number of IMU measurements: " << imu_buffer_.size();
+}
 
 }  // namespace VIO

--- a/src/imu-frontend/ImuFrontEnd.cpp
+++ b/src/imu-frontend/ImuFrontEnd.cpp
@@ -17,21 +17,15 @@
 
 #include <glog/logging.h>
 
+#include <gtsam/navigation/AHRSFactor.h>
+#include <gtsam/navigation/CombinedImuFactor.h>  // Used if IMU combined is off.
+#include <gtsam/navigation/ImuFactor.h>
+
 #include "kimera-vio/common/vio_types.h"
 #include "kimera-vio/imu-frontend/ImuFrontEnd-definitions.h"
 #include "kimera-vio/utils/UtilsNumerical.h"
 
 namespace VIO {
-
-/* -------------------------------------------------------------------------- */
-void ImuData::print() const {
-  LOG(INFO) << "------------ ImuData::print -------------\n"
-            << "\nnominal_imu_rate: " << nominal_imu_rate_ << '\n'
-            << "imu_rate: " << imu_rate_ << '\n'
-            << "imu_rate_std: " << imu_rate_std_ << '\n'
-            << "imu_rate_maxMismatch: " << imu_rate_maxMismatch_ << '\n'
-            << "nr of imu measurements: " << imu_buffer_.size();
-}
 
 ImuFrontEnd::ImuFrontEnd(const ImuParams& imu_params, const ImuBias& imu_bias)
     : imu_params_(imu_params) {

--- a/src/initial/InitializationBackEnd.cpp
+++ b/src/initial/InitializationBackEnd.cpp
@@ -33,13 +33,13 @@ InitializationBackEnd::InitializationBackEnd(
     const BackendParams& backend_params,
     const ImuParams& imu_params,
     const BackendOutputParams& backend_output_params,
-    const bool log_output)
+    const std::string& log_output_path)
     : VioBackEnd(B_Pose_leftCam,
                  stereo_calibration,
                  backend_params,
                  imu_params,
                  backend_output_params,
-                 log_output) {}
+                 log_output_path) {}
 
 /* ------------------------------------------------------------------------ */
 // Perform Bundle-Adjustment and initial gravity alignment

--- a/src/loopclosure/LoopClosureDetector.cpp
+++ b/src/loopclosure/LoopClosureDetector.cpp
@@ -52,9 +52,8 @@ namespace VIO {
 /* ------------------------------------------------------------------------ */
 LoopClosureDetector::LoopClosureDetector(
     const LoopClosureDetectorParams& lcd_params,
-    bool log_output)
+    const std::string& log_output_path)
     : lcd_params_(lcd_params),
-      log_output_(log_output),
       set_intrinsics_(false),
       orb_feature_detector_(),
       orb_feature_matcher_(),
@@ -114,7 +113,9 @@ LoopClosureDetector::LoopClosureDetector(
                                   KimeraRPGO::Verbosity::QUIET);
   pgo_ = VIO::make_unique<KimeraRPGO::RobustSolver>(pgo_params);
 
-  if (log_output) logger_ = VIO::make_unique<LoopClosureDetectorLogger>();
+  if (!log_output_path.empty()) {
+    logger_ = VIO::make_unique<LoopClosureDetectorLogger>(log_output_path);
+  }
 }
 
 LoopClosureDetector::~LoopClosureDetector() {

--- a/src/pipeline/Pipeline-definitions.cpp
+++ b/src/pipeline/Pipeline-definitions.cpp
@@ -59,6 +59,7 @@ VioParams::VioParams(const std::string& params_folder_path,
       frontend_type_(FrontendType::kStereoImu),
       backend_type_(BackendType::kStructuralRegularities),
       parallel_run_(true),
+      log_output_path_(""),
       // Filepaths, keep defaults unless you changed file names.
       pipeline_params_filename_(pipeline_params_filename),
       imu_params_filename_(imu_params_filename),
@@ -86,6 +87,7 @@ bool VioParams::parseYAML(const std::string& folder_path) {
   yaml_parser.getYamlParam("frontend_type", &frontend_type);
   frontend_type_ = static_cast<FrontendType>(frontend_type);
   yaml_parser.getYamlParam("parallel_run", &parallel_run_);
+  yaml_parser.getYamlParam("log_output_path", &log_output_path_);
 
   // Parse IMU params
   parsePipelineParams(folder_path + '/' + imu_params_filename_, &imu_params_);
@@ -134,10 +136,11 @@ void VioParams::print() const {
   CHECK(backend_params_);
   backend_params_->print();
   lcd_params_.print();
-  LOG(INFO) << "Frontend Type: " << VIO::to_underlying(frontend_type_);
-  LOG(INFO) << "Backend Type: " << VIO::to_underlying(backend_type_);
-  LOG(INFO) << "Running VIO in " << (parallel_run_ ? "parallel" : "sequential")
-            << " mode.";
+  LOG(INFO) << "Frontend Type: " << VIO::to_underlying(frontend_type_) << '\n'
+            << "Backend Type: " << VIO::to_underlying(backend_type_) << '\n'
+            << "Running VIO in " << (parallel_run_ ? "parallel" : "sequential")
+            << " mode." << '\n'
+            << "Log output path: " << log_output_path_.c_str();
 }
 
 //! Helper function to parse camera params.

--- a/src/visualizer/Visualizer3D.cpp
+++ b/src/visualizer/Visualizer3D.cpp
@@ -83,12 +83,13 @@ namespace VIO {
 
 /* -------------------------------------------------------------------------- */
 Visualizer3D::Visualizer3D(const VisualizationType& viz_type,
-                           const BackendType& backend_type)
+                           const BackendType& backend_type,
+                           const std::string& log_output_path)
     : visualization_type_(viz_type),
       backend_type_(backend_type),
       logger_(nullptr) {
-  if (FLAGS_log_mesh) {
-    logger_ = VIO::make_unique<VisualizerLogger>();
+  if (!log_output_path.empty() && FLAGS_log_mesh) {
+    logger_ = VIO::make_unique<VisualizerLogger>(log_output_path);
   }
 }
 

--- a/src/visualizer/Visualizer3DFactory.cpp
+++ b/src/visualizer/Visualizer3DFactory.cpp
@@ -16,22 +16,4 @@
 
 namespace VIO {
 
-Visualizer3D::UniquePtr VisualizerFactory::createVisualizer(
-    const VisualizerType visualizer_type,
-    const VisualizationType& viz_type,
-    const BackendType& backend_type) {
-  switch (visualizer_type) {
-    case VisualizerType::OpenCV: {
-      return VIO::make_unique<Visualizer3D>(viz_type, backend_type);
-    }
-    default: {
-      LOG(FATAL) << "Requested visualizer type is not supported.\n"
-                 << "Currently supported visualizer types:\n"
-                 << "0: OpenCV 3D viz\n 1: Pangolin (not supported yet)\n"
-                 << " but requested visualizer: "
-                 << static_cast<int>(visualizer_type);
-    }
-  }
-}
-
 }  // namespace VIO

--- a/tests/testLoopClosureDetector.cpp
+++ b/tests/testLoopClosureDetector.cpp
@@ -70,7 +70,7 @@ class LCDFixture :public ::testing::Test {
         FLAGS_test_data_path +
         std::string("/ForLoopClosureDetector/small_voc.yml.gz");
 
-    lcd_detector_ = VIO::make_unique<LoopClosureDetector>(params, false);
+    lcd_detector_ = VIO::make_unique<LoopClosureDetector>(params);
 
     ref1_pose_ = gtsam::Pose3(
         gtsam::Rot3(gtsam::Quaternion(0.338337, 0.608466, -0.535476, 0.478082)),

--- a/tests/testVioBackEnd.cpp
+++ b/tests/testVioBackEnd.cpp
@@ -213,8 +213,7 @@ TEST(testVio, robotMovingWithConstantVelocity) {
                                    stereo_calibration,
                                    vioParams,
                                    imu_params,
-                                   BackendOutputParams(false, 0, false),
-                                   false);
+                                   BackendOutputParams(false, 0, false));
   vio->registerImuBiasUpdateCallback(std::bind(
       &ImuFrontEnd::updateBias, std::ref(imu_frontend), std::placeholders::_1));
   vio->initStateAndSetPriors(VioNavStateTimestamped(t_start, initial_state));


### PR DESCRIPTION
- Now each logger can have a different output path, but we are only
using one output path. This is to allow for logging to different dirs
depending on the current run, without having to kill the pipeline (this
    is for go-seek mainly).
- Remove log_output gflag and use instead the `log_output_path` yaml parameter
in PipelineParams.yaml. If this parameter is empty "" then no logging is done