### PR TITLE
Using boost::random instead of std::random

### DIFF
--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <algorithm>
 #include <random>
+#include <boost/random.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <gflags/gflags.h>
@@ -82,7 +83,7 @@ class LoggerFixture : public ::testing::Test {
  protected:
   std::string logger_FLAGS_test_data_path;
   CSVReader csv_reader_;
-  std::mt19937 rng_;
+  boost::random::mt19937 rng_;
   std::default_random_engine random_eng_;
 };
 


### PR DESCRIPTION
**Please** take care.

Please test the new build is passing correctly, 
at https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/53
and at https://github.com/MIT-SPARK/Kimera-VIO-ROS/issues/74
I am finding the same comments, and the advice is to change the gtsam branch by another one.

With the current configuration (using boost random) the build completes without any problem at all, without the need of changing branches.