### PR TITLE
Feature/add fast and faster configurations

### DIFF
--- a/docs/tips_usage.md
+++ b/docs/tips_usage.md
@@ -6,6 +6,10 @@
     - Running in parallel (default): `parallel_run=1`.
     - Running in sequential mode: `parallel_run=0`. Or, if using the example script, use the `-s` flag at commandline.
 - Log output in csv files: gflag `log_output=true`. Or, if using the example script, use the `-log` commandline argument. By default, log files will be saved in `output_logs` directory.
+- Running on slower hardware: We provide flags to scale certain parameters to decrease computational load (at the potential expense of accuracy):
+    - Fast mode: gflag `--fast`. This currently scales down the parameters `maxNumberFeaturesPerFrame` and `horizon`
+    - Faster mode: gflag `--faster`. This currently scales down the parameters `maxNumberFeaturesPerFrame` and `horizon` twice.
+
 
 ## Loop Closure Detector
 

--- a/docs/tips_usage.md
+++ b/docs/tips_usage.md
@@ -7,8 +7,8 @@
     - Running in sequential mode: `parallel_run=0`. Or, if using the example script, use the `-s` flag at commandline.
 - Log output in csv files: gflag `log_output=true`. Or, if using the example script, use the `-log` commandline argument. By default, log files will be saved in `output_logs` directory.
 - Running on slower hardware: We provide flags to scale certain parameters to decrease computational load (at the potential expense of accuracy):
-    - Fast mode: gflag `--fast`. This currently scales down the parameters `maxNumberFeaturesPerFrame` and `horizon`
-    - Faster mode: gflag `--faster`. This currently scales down the parameters `maxNumberFeaturesPerFrame` and `horizon` twice.
+    - Fast mode: gflag `--fast`. This currently scales down the parameters `maxFeaturesPerFrame` and `horizon`
+    - Faster mode: gflag `--faster`. This currently scales down the parameters `maxFeaturesPerFrame` and `horizon` twice.
 
 
 ## Loop Closure Detector

--- a/include/kimera-vio/backend/VioBackEndParams.h
+++ b/include/kimera-vio/backend/VioBackEndParams.h
@@ -14,18 +14,17 @@
 
 #pragma once
 
+#include <glog/logging.h>
+#include <gtsam/base/Vector.h>
+#include <gtsam/slam/SmartFactorParams.h>
 #include <stdlib.h>
+
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include <gtsam/base/Vector.h>
-#include <gtsam/slam/SmartFactorParams.h>
-
-#include <glog/logging.h>
 
 #include "kimera-vio/common/VioNavState.h"
 #include "kimera-vio/pipeline/PipelineParams.h"
@@ -87,6 +86,9 @@ class BackendParams : public PipelineParams {
   void printVioBackEndParams() const;
 
  public:
+  //! Factor to decrease horizon by in "fast" or "faster" mode
+  static constexpr double horizon_performance_scaling_ = 11.0 / 12.0;
+
   //! Initialization params
   int autoInitialize_ = 0;
   double initialPositionSigma_ = 0.00001;

--- a/include/kimera-vio/frontend/feature-detector/FeatureDetectorParams.h
+++ b/include/kimera-vio/frontend/feature-detector/FeatureDetectorParams.h
@@ -47,7 +47,6 @@ struct SubPixelCornerFinderParams : public PipelineParams {
   cv::Size zero_zone_ = cv::Size(-1, -1);
 };
 
-
 struct FeatureDetectorParams : public PipelineParams {
  public:
   KIMERA_POINTER_TYPEDEFS(FeatureDetectorParams);
@@ -67,6 +66,9 @@ struct FeatureDetectorParams : public PipelineParams {
   }
 
  public:
+  //! Factor to decrease features by in "fast" or "faster" mode
+  static constexpr double num_features_performance_scaling_ = 2.0 / 3.0;
+
   FeatureDetectorType feature_detector_type_ = FeatureDetectorType::GFTT;
   //! Maximum amount of features to be detected per frame.
   int max_features_per_frame_ = 400;

--- a/src/backend/VioBackEndParams.cpp
+++ b/src/backend/VioBackEndParams.cpp
@@ -109,11 +109,13 @@ bool BackendParams::parseYAMLVioBackEndParams(const YamlParser& yaml_parser) {
   yaml_parser.getYamlParam("numOptimize", &numOptimize_);
   yaml_parser.getYamlParam("horizon", &horizon_);
   if (FLAGS_fast or FLAGS_faster) {
-    double ratio = std::pow(horizon_performance_scaling_, (FLAGS_fast ? 1 : 2));
+    // default to faster if both are active
+    double ratio =
+        std::pow(horizon_performance_scaling_, (FLAGS_faster ? 2 : 1));
     double old_horizon = horizon_;
     horizon_ = ratio * old_horizon;
     LOG(WARNING) << "Decreased horizon from " << old_horizon << " to "
-                 << horizon_ << " for " << (FLAGS_fast ? "fast" : "faster")
+                 << horizon_ << " for " << (FLAGS_faster ? "faster" : "fast")
                  << " performance mode";
   }
 

--- a/src/frontend/feature-detector/FeatureDetectorParams.cpp
+++ b/src/frontend/feature-detector/FeatureDetectorParams.cpp
@@ -170,13 +170,14 @@ bool FeatureDetectorParams::parseYAML(const std::string& filepath) {
 
   yaml_parser.getYamlParam("maxFeaturesPerFrame", &max_features_per_frame_);
   if (FLAGS_fast or FLAGS_faster) {
+    // ternary operator order defaults to faster if fast and faster are true
     double ratio =
-        std::pow(num_features_performance_scaling_, (FLAGS_fast ? 1 : 2));
+        std::pow(num_features_performance_scaling_, (FLAGS_faster ? 2 : 1));
     int old_num = max_features_per_frame_;
     max_features_per_frame_ = static_cast<int>(std::floor(ratio * old_num));
     LOG(WARNING) << "Decreased from " << old_num << " to "
                  << max_features_per_frame_ << " maximum features for "
-                 << (FLAGS_fast ? "fast" : "faster") << " performance mode";
+                 << (FLAGS_faster ? "faster" : "fast") << " performance mode";
   }
 
   // GFTT specific parameters

--- a/src/frontend/feature-detector/FeatureDetectorParams.cpp
+++ b/src/frontend/feature-detector/FeatureDetectorParams.cpp
@@ -13,10 +13,14 @@
  */
 
 #include "kimera-vio/frontend/feature-detector/FeatureDetectorParams.h"
+
 #include "kimera-vio/frontend/VisionFrontEndParams.h"
 #include "kimera-vio/frontend/feature-detector/NonMaximumSuppression.h"
 #include "kimera-vio/frontend/feature-detector/anms/anms.h"  // REMOVE
 #include "kimera-vio/utils/YamlParser.h"
+
+DECLARE_bool(fast);
+DECLARE_bool(faster);
 
 namespace VIO {
 
@@ -165,6 +169,15 @@ bool FeatureDetectorParams::parseYAML(const std::string& filepath) {
   }
 
   yaml_parser.getYamlParam("maxFeaturesPerFrame", &max_features_per_frame_);
+  if (FLAGS_fast or FLAGS_faster) {
+    double ratio =
+        std::pow(num_features_performance_scaling_, (FLAGS_fast ? 1 : 2));
+    int old_num = max_features_per_frame_;
+    max_features_per_frame_ = static_cast<int>(std::floor(ratio * old_num));
+    LOG(WARNING) << "Decreased from " << old_num << " to "
+                 << max_features_per_frame_ << " maximum features for "
+                 << (FLAGS_fast ? "fast" : "faster") << " performance mode";
+  }
 
   // GFTT specific parameters
   yaml_parser.getYamlParam("quality_level", &quality_level_);

--- a/src/pipeline/Pipeline-definitions.cpp
+++ b/src/pipeline/Pipeline-definitions.cpp
@@ -16,6 +16,9 @@
 
 #include "kimera-vio/pipeline/Pipeline-definitions.h"
 
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
 #include "kimera-vio/backend/RegularVioBackEndParams.h"
 #include "kimera-vio/backend/VioBackEnd-definitions.h"
 #include "kimera-vio/backend/VioBackEndParams.h"
@@ -26,8 +29,11 @@
 #include "kimera-vio/imu-frontend/ImuFrontEndParams.h"
 #include "kimera-vio/loopclosure/LoopClosureDetectorParams.h"
 
-#include <gflags/gflags.h>
-#include <glog/logging.h>
+// flags to tune computational performance at the expense of accuracy
+DEFINE_bool(fast, false, "Decrease number of features and horizon size");
+DEFINE_bool(faster,
+            false,
+            "Decrease number of features and horizon size even more");
 
 namespace VIO {
 
@@ -77,6 +83,9 @@ VioParams::VioParams(const std::string& params_folder_path,
 }
 
 bool VioParams::parseYAML(const std::string& folder_path) {
+  if (FLAGS_fast and FLAGS_faster) {
+    LOG(WARNING) << "Both fast and faster selected; defaulting to faster";
+  }
   // Create a parser for pipeline params.
   YamlParser yaml_parser(folder_path + '/' + pipeline_params_filename_);
   int backend_type;
@@ -136,6 +145,8 @@ void VioParams::print() const {
   lcd_params_.print();
   LOG(INFO) << "Frontend Type: " << VIO::to_underlying(frontend_type_);
   LOG(INFO) << "Backend Type: " << VIO::to_underlying(backend_type_);
+  LOG(INFO) << "Performance Mode: "
+            << (FLAGS_faster ? "faster" : (FLAGS_fast ? "fast" : "normal"));
   LOG(INFO) << "Running VIO in " << (parallel_run_ ? "parallel" : "sequential")
             << " mode.";
 }

--- a/tests/testFeatureDetectorParams.cpp
+++ b/tests/testFeatureDetectorParams.cpp
@@ -13,6 +13,8 @@
 #include "kimera-vio/frontend/feature-detector/FeatureDetectorParams.h"
 
 DECLARE_string(test_data_path);
+DECLARE_bool(fast);
+DECLARE_bool(faster);
 
 namespace VIO {
 
@@ -37,7 +39,8 @@ TEST(testFeatureDetectorParams, FeatureDetectorParamParseYAML) {
   EXPECT_EQ(VIO::to_underlying(tp.feature_detector_type_), 0);
   EXPECT_EQ(tp.max_features_per_frame_, 200);
   EXPECT_EQ(tp.enable_subpixel_corner_refinement_, true);
-  EXPECT_TRUE(tp.subpixel_corner_finder_params_.equals(expected_subpixel_params));
+  EXPECT_TRUE(
+      tp.subpixel_corner_finder_params_.equals(expected_subpixel_params));
   EXPECT_EQ(tp.enable_non_max_suppression_, true);
   EXPECT_EQ(VIO::to_underlying(tp.non_max_suppression_type_), 4);
   EXPECT_EQ(tp.quality_level_, 0.5);
@@ -50,6 +53,66 @@ TEST(testFeatureDetectorParams, FeatureDetectorParamParseYAML) {
 TEST(testFeatureDetectorParams, equals) {
   FeatureDetectorParams tp = FeatureDetectorParams();
   EXPECT_TRUE(tp.equals(tp));
+}
+
+TEST(testFeatureDetectorParams, FastAndFasterModifications) {
+  // check that fast and faster appropriately adjust the number of features
+  int default_value = 0;
+  {  // default parameter closure
+    FeatureDetectorParams tp;
+    tp.parseYAML(FLAGS_test_data_path + "/ForTracker/trackerParameters.yaml");
+    default_value = tp.max_features_per_frame_;
+  }
+
+  int fast_value = 0;
+  {  // fast parameter closure
+    google::FlagSaver saver;
+    FLAGS_fast = true;
+    FeatureDetectorParams tp;
+    tp.parseYAML(FLAGS_test_data_path + "/ForTracker/trackerParameters.yaml");
+    fast_value = tp.max_features_per_frame_;
+  }
+
+  int faster_value = 0;
+  {  // faster parameter closure
+    google::FlagSaver saver;
+    FLAGS_faster = true;
+    FeatureDetectorParams tp;
+    tp.parseYAML(FLAGS_test_data_path + "/ForTracker/trackerParameters.yaml");
+    faster_value = tp.max_features_per_frame_;
+  }
+  EXPECT_NE(default_value, 0);
+  EXPECT_NE(fast_value, 0);
+  EXPECT_NE(faster_value, 0);
+  EXPECT_LE(fast_value, default_value);
+  EXPECT_LE(faster_value, fast_value);
+  double fast_to_default_ratio =
+      fast_value / static_cast<double>(default_value);
+  double faster_to_fast_ratio = faster_value / static_cast<double>(fast_value);
+  EXPECT_NEAR(fast_to_default_ratio, faster_to_fast_ratio, 1.0e-2);
+}
+
+TEST(testFeatureDetectorParams, FastAndFasterConflict) {
+  // check that fast and faster together results in faster configuration
+  int faster_value = 0;
+  {  // fast parameter closure
+    google::FlagSaver saver;
+    FLAGS_faster = true;
+    FeatureDetectorParams tp;
+    tp.parseYAML(FLAGS_test_data_path + "/ForTracker/trackerParameters.yaml");
+    faster_value = tp.max_features_per_frame_;
+  }
+
+  int combined_value = 0;
+  {  // faster parameter closure
+    google::FlagSaver saver;
+    FLAGS_fast = true;
+    FLAGS_faster = true;
+    FeatureDetectorParams tp;
+    tp.parseYAML(FLAGS_test_data_path + "/ForTracker/trackerParameters.yaml");
+    combined_value = tp.max_features_per_frame_;
+  }
+  EXPECT_EQ(faster_value, combined_value);
 }
 
 }  // namespace VIO


### PR DESCRIPTION
Adds the ability to scale the parameters that we've determined most affect computational performance via `--fast` and `--faster` gflags.  More specifically, this adds the following:

- Scales `maxFeaturesPerFrame` by ~0.83 in the fast configuration and ~0.7 in the faster configuration
- Scales `horizon` by ~0.91 in the fast configuration and ~0.84 in the faster configuration
- Log messages to warn the user that parameters were changed
- Associated unit tests

The scale factors are currently captured as `constexpr` both because I don't see an use case for changing the scaling parameters at runtime (as the user can just change the parameters directly and not use the flags provided) and because relying on parameter parsing order to pick up the scale factors first seems brittle.