### PR TITLE
Feature/add fast euroc parameters

### DIFF
--- a/docs/tips_usage.md
+++ b/docs/tips_usage.md
@@ -57,6 +57,6 @@ This is useful for example for the Euroc dataset `V1_01_*` where we are given a 
 
 ## Running on slower hardware
 
-- See [this directory](params/EurocFast) for a configuration that is faster (but potentially less accurate)
+- See [this directory](../params/EurocFaster) for a configuration that is faster (but potentially less accurate)
   - If even less computational overhead is needed, another configuration would be `maxFeaturePerFrame=200` and `horizon=4.5`
 

--- a/docs/tips_usage.md
+++ b/docs/tips_usage.md
@@ -54,3 +54,9 @@ This is useful for example for the Euroc dataset `V1_01_*` where we are given a 
       property list uint8 int32 vertex_indices
       end_header
       ```
+
+## Running on slower hardware
+
+- See [this directory](params/EurocFast) for a configuration that is faster (but potentially less accurate)
+  - If even less computational overhead is needed, another configuration would be `maxFeaturePerFrame=200` and `horizon=4.5`
+

--- a/params/EurocFaster/BackendParams.yaml
+++ b/params/EurocFaster/BackendParams.yaml
@@ -1,0 +1,91 @@
+%YAML:1.0
+# Backend modality for regular VIO
+# 0: Structureless factors only, 4: SPR pipeline
+backend_modality: 0
+
+# IMU PARAMETERS #############################################################
+gyroNoiseDensity: 0.00016968
+accNoiseDensity: 0.002
+gyroBiasSigma: 1.9393e-05
+accBiasSigma: 0.003
+imuIntegrationSigma: 1.0e-8
+n_gravity: [0.0, 0.0, -9.81]
+nominalImuRate: 0.005
+#INITIALIZATION PARAMETERS
+autoInitialize: 0
+roundOnAutoInitialize: 0
+initialPositionSigma: 1e-05
+initialRollPitchSigma: 0.174533 # 10.0/180.0*M_PI
+initialYawSigma: 0.00174533 # 0.1/180.0*M_PI
+initialVelocitySigma: 0.001
+initialAccBiasSigma: 0.1
+initialGyroBiasSigma: 0.01
+
+# VISION PARAMETERS ###########################################################
+## Smart Factors ##
+#
+# How to linearize the factor:
+# 0: Hessian, 1: Implicit Schur, 2:Jacobian_Q, 3:Jacobian_SVD
+linearizationMode: 0
+# How to manage degeneracy
+# 0: Ignore degeneracy, 1: Zero on degeneracy, 2: handle infinity
+degeneracyMode: 1
+# rankTolerance: threshold to decide whether triangulation is result.degenerate
+# (the rank is the number of singular values of the triangulation matrix which
+# are larger than rankTolerance)
+rankTolerance: 1
+# /** landmarkDistanceThreshold
+#   * if the landmark is triangulated at distance larger than this,
+#   * result is flagged as degenerate.
+#   */
+landmarkDistanceThreshold: 10
+
+# DynamicOutlierRejection:
+#  /**
+#   * If this is nonnegative the we will check if the average reprojection error
+#   * is smaller than this threshold after triangulation, otherwise result is
+#   * flagged as degenerate.
+#   */
+outlierRejection: 3
+# ///< threshold to decide whether to re-triangulate
+retriangulationThreshold: 0.001
+
+## Noise models ##
+smartNoiseSigma: 3.0
+monoNoiseSigma: 1.8
+monoNormType: 2
+monoNormParam: 4.6851
+stereoNoiseSigma: 1.8
+stereoNormType: 2
+stereoNormParam: 4.6851
+regularityNoiseSigma: 0.03
+regularityNormType: 1
+regularityNormParam: 0.04
+
+## Between Stereo Factors ##
+addBetweenStereoFactors: 1
+betweenRotationPrecision: 0 # Inverse of variance.
+betweenTranslationPrecision: 100 # 1/(0.1*0.1)
+
+# OPTIMIZATION PARAMETERS #####################################################
+relinearizeThreshold: 0.01
+relinearizeSkip: 1
+zeroVelocitySigma: 0.001
+noMotionPositionSigma: 0.001
+noMotionRotationSigma: 0.0001
+constantVelSigma: 0.01
+numOptimize: 1
+horizon: 5 # In seconds.
+# ISAM2GaussNewtonParams: continue updating the linear delta only when
+# changes are above this threshold (default: 0.001)
+wildfire_threshold: 0.001
+useDogLeg: 0
+
+## NON PARSED PARAMS ##########################################################
+#  bool enableEPI; ///< if set to true, will refine triangulation using LM
+#  /**
+#   * If this is nonnegative the we will check if the average reprojection error
+#   * is smaller than this threshold after triangulation, otherwise result is
+#   * flagged as degenerate.
+#   */
+#  double dynamicOutlierRejectionThreshold;

--- a/params/EurocFaster/FrontendParams.yaml
+++ b/params/EurocFaster/FrontendParams.yaml
@@ -1,0 +1,67 @@
+%YAML:1.0
+#TRACKER PARAMETERS
+klt_win_size: 24
+klt_max_iter: 30
+klt_max_level: 4
+klt_eps: 0.1
+maxFeatureAge: 25
+
+# Detector Params
+# 0: FAST
+# 1: ORB
+# 2: AGAST
+# 3: GFTT, aka Good Features To Track
+feature_detector_type: 3
+maxFeaturesPerFrame: 250
+
+# Good Features To Track specific parameters
+quality_level: 0.001
+min_distance: 20
+block_size: 3
+use_harris_detector: 0
+k: 0.04
+
+# FAST detector specific parameters [10, 20]
+fast_thresh: 10
+
+equalizeImage: 0
+nominalBaseline: 0.11
+toleranceTemplateMatching: 0.15
+templ_cols: 101 #must be odd
+templ_rows: 11
+stripe_extra_rows: 0
+minPointDist: 0.5
+maxPointDist: 10
+bidirectionalMatching: 0
+
+# Non-maximum suppression params
+enable_non_max_suppression: 1
+non_max_suppression_type: 4
+
+# Subpixel corner refinement for the monocular case
+enable_subpixel_corner_finder: 1
+max_iters: 40
+epsilon_error: 0.001
+window_size: 10
+zero_zone: -1
+
+subpixelRefinementStereo: 0
+useSuccessProbabilities: 1
+useRANSAC: 1
+minNrMonoInliers: 10
+minNrStereoInliers: 5
+ransac_threshold_mono: 1e-06
+ransac_threshold_stereo: 1
+ransac_use_1point_stereo: 1
+ransac_use_2point_mono: 1
+ransac_max_iterations: 100
+ransac_probability: 0.995
+ransac_randomize: 0
+intra_keyframe_time: 0.2
+minNumberFeatures: 0
+useStereoTracking: 1
+disparityThreshold: 0.5
+# Type of optical flow predictor to aid feature tracking:
+# 0: Static - assumes no optical flow between images (aka static camera).
+# 1: Rotational - use IMU gyro to estimate optical flow.
+optical_flow_predictor_type: 1

--- a/params/EurocFaster/ImuParams.yaml
+++ b/params/EurocFaster/ImuParams.yaml
@@ -1,0 +1,1 @@
+../Euroc/ImuParams.yaml

--- a/params/EurocFaster/LcdParams.yaml
+++ b/params/EurocFaster/LcdParams.yaml
@@ -1,0 +1,1 @@
+../Euroc/LcdParams.yaml

--- a/params/EurocFaster/LeftCameraParams.yaml
+++ b/params/EurocFaster/LeftCameraParams.yaml
@@ -1,0 +1,1 @@
+../Euroc/LeftCameraParams.yaml

--- a/params/EurocFaster/PipelineParams.yaml
+++ b/params/EurocFaster/PipelineParams.yaml
@@ -1,0 +1,1 @@
+../Euroc/PipelineParams.yaml

--- a/params/EurocFaster/RightCameraParams.yaml
+++ b/params/EurocFaster/RightCameraParams.yaml
@@ -1,0 +1,1 @@
+../Euroc/RightCameraParams.yaml

--- a/params/EurocFaster/flags
+++ b/params/EurocFaster/flags
@@ -1,0 +1,1 @@
+../Euroc/flags


### PR DESCRIPTION
Adds a new example configuration for Euroc with a smaller `maxFeaturesPerFrame` and `horizon`, as well as a quick blurb in the usage tips documentation.