### PR TITLE
Fix/Update fields in LcdThirdPartyWrapper to allow loop closures

### DIFF
--- a/src/loopclosure/LcdThirdPartyWrapper.cpp
+++ b/src/loopclosure/LcdThirdPartyWrapper.cpp
@@ -105,6 +105,8 @@ bool LcdThirdPartyWrapper::checkTemporalConstraint(const FrameId& id,
     }
   }
 
+  latest_matched_island_ = island;
+  latest_query_id_ = id;
   return temporal_entries_ > lcd_params_.min_temporal_matches_;
 }
 


### PR DESCRIPTION
Currently latest_query_id_ and latest_matched_island_ are never updated from 0 values, so after the first 2 frames, all frames will fail the temporal constraint, resulting in LoopClosureDetector never finding any loops or outputting LCDStatus::LOOP_DETECTED.

Fix is based on the breaking commit, which looks like it accidentally deleted these lines: ec0682a81f81a8a77cfeba6846510393fcdfaf2f

Tested by:
1) Inserting LOGs to confirm that all frames processed by LcdThirdPartyWrapper::checkTemporalConstraint fall into the first if statement and thus have temporal_entries_ == 1 ==  lcd_params_.min_temporal_matches_, so the function returns false
2) With the below change, I ran kimera_vio_ros_euroc.launch and found that I now got out loop closures in output_lcd_status.csv