### PR TITLE
Return the current frame for non keyframe frontend output

### DIFF
--- a/src/frontend/MonoVisionImuFrontend.cpp
+++ b/src/frontend/MonoVisionImuFrontend.cpp
@@ -174,7 +174,7 @@ MonoFrontendOutput::UniquePtr MonoVisionImuFrontend::nominalSpinMono(
         TrackingStatus::DISABLED,  // This is a stereo status only
         gtsam::Pose3::identity(),  // don't pass stereo pose to Backend!
         mono_camera_->getBodyPoseCam(),
-        *mono_frame_lkf_,  //! This is really the current keyframe in this if
+        *mono_frame_km1_,
         pim,
         input->getImuAccGyrs(),
         feature_tracks,

--- a/src/frontend/StereoVisionImuFrontend.cpp
+++ b/src/frontend/StereoVisionImuFrontend.cpp
@@ -220,7 +220,7 @@ StereoFrontendOutput::UniquePtr StereoVisionImuFrontend::nominalSpinStereo(
             : gtsam::Pose3::identity(),
         stereo_camera_->getBodyPoseLeftCamRect(),
         stereo_camera_->getBodyPoseRightCamRect(),
-        *stereoFrame_lkf_,
+        *stereoFrame_km1_,
         pim,
         input->getImuAccGyrs(),
         feature_tracks,


### PR DESCRIPTION
- Allow to use frontend results between the keyframes. In particular,
it is useful to have access to the timestamp of the current frame.