### PR TITLE
Remove explicit -march=native as it should be inherited from GTSAM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,6 @@ endif(Pangolin_FOUND)
 
 target_compile_options(${PROJECT_NAME}
   PRIVATE -Wall -pipe
-  PRIVATE -march=native
 )
 
 # We would just need to say cxx_std_11 if we were using cmake 3.8

--- a/src/utils/Histogram.cpp
+++ b/src/utils/Histogram.cpp
@@ -67,7 +67,7 @@ Histogram::~Histogram() {
   delete[] channels_;
   delete[] hist_size_;
   for (int dim = 0; dim < dims_; dim++) {
-    delete ranges_[dim];
+    delete[] ranges_[dim];
   }
   delete[] ranges_;
 }


### PR DESCRIPTION
As explained in https://github.com/MIT-SPARK/Kimera-RPGO/pull/68 the `-march=native` flag is already inherited from GTSAM. Adding to that, if GTSAM disables `-march=native` having it hardcoded here introduces difficult-to-debug crashes.