### PR TITLE
Fix for the Dockerfile, and made the code compatible with the current master branch of GTSAM

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 MAINTAINER Antoni Rosinol "arosinol@mit.edu"
 
 # To avoid tzdata asking for geographic location...
-ENV DEBIAN_frontend noninteractive
+ENV DEBIAN_FRONTEND noninteractive
 
 # Set the working directory to /root
 ENV DIRPATH /root
@@ -103,6 +103,7 @@ RUN python3.5 $(which pip3) install ipython prompt_toolkit
 # Hack to avoid Docker's cache when spark_vio_evaluation master branch is updated.
 ADD https://api.github.com/repos/ToniRV/Kimera-VIO-Evaluation/git/refs/heads/master version.json
 RUN git clone https://github.com/ToniRV/Kimera-VIO-Evaluation.git
+RUN apt install libffi-dev -y
 # We use `pip3 install -e .` so that Jinja2 has access to the webiste template...
 RUN cd Kimera-VIO-Evaluation && python3.5 $(which pip3) install -e .
 
@@ -120,7 +121,7 @@ RUN ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
 RUN apt-get update && apt-get install -y libgflags2.2 libgflags-dev libgoogle-glog0v5 libgoogle-glog-dev
 
 # Install Kimera-VIO
-RUN git clone https://github.com/MIT-SPARK/Kimera-VIO.git
+RUN git clone https://github.com/sanderfo/Kimera-VIO.git
 RUN cd Kimera-VIO && mkdir build && cd build && cmake .. && make -j$(nproc)
 
 # Download and extract EuRoC dataset.

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -121,7 +121,7 @@ RUN ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
 RUN apt-get update && apt-get install -y libgflags2.2 libgflags-dev libgoogle-glog0v5 libgoogle-glog-dev
 
 # Install Kimera-VIO
-RUN git clone https://github.com/sanderfo/Kimera-VIO.git
+RUN git clone https://github.com/MIT-SPARK/Kimera-VIO.git
 RUN cd Kimera-VIO && mkdir build && cd build && cmake .. && make -j$(nproc)
 
 # Download and extract EuRoC dataset.

--- a/src/backend/VioBackendParams.cpp
+++ b/src/backend/VioBackendParams.cpp
@@ -43,12 +43,12 @@ void BackendParams::setIsam2Params(const BackendParams& vio_params,
 
   // TODO (Toni): remove hardcoded
   // Cache Linearized Factors seems to improve performance.
-  isam_param->setCacheLinearizedFactors(true);
+  isam_param->cacheLinearizedFactors = true;
   isam_param->relinearizeThreshold = vio_params.relinearizeThreshold_;
   isam_param->relinearizeSkip = vio_params.relinearizeSkip_;
   isam_param->findUnusedFactorSlots = true;
   // isam_param->enablePartialRelinearizationCheck = true;
-  isam_param->setEvaluateNonlinearError(false);  // only for debugging
+  isam_param->evaluateNonlinearError = false;  // only for debugging
   isam_param->enableDetailedResults = false;     // only for debugging.
   isam_param->factorization = gtsam::ISAM2Params::CHOLESKY;  // QR
 }

--- a/tests/testPointPlaneFactor.cpp
+++ b/tests/testPointPlaneFactor.cpp
@@ -67,8 +67,8 @@ void setIsam2Params(const BackendParams& vio_params,
   }
 
   // Here there was commented code about setRelinearizeThreshold.
-  isam_param->setCacheLinearizedFactors(false);
-  isam_param->setEvaluateNonlinearError(true);
+  isam_param->cacheLinearizedFactors = false;
+  isam_param->evaluateNonlinearError = true;
   isam_param->relinearizeThreshold = vio_params.relinearizeThreshold_;
   isam_param->relinearizeSkip = vio_params.relinearizeSkip_;
   // isam_param->enablePartialRelinearizationCheck = true;


### PR DESCRIPTION
Currently, the Docker install does not work, for two reasons. The first issue is described in https://github.com/MIT-SPARK/Kimera-VIO/issues/180 . The second reason is that Kimera-VIO does not compile with the current master branch of GTSAM, as they have removed the deprecated way to set evaluateNonlinearError and cacheLinearizedFactors. I have updated Kimera-VIO to account for this.