### PR TITLE
Including installation for metis in dockerfile

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER Antoni Rosinol "arosinol@mit.edu"
 
 # To avoid tzdata asking for geographic location...
 ENV DEBIAN_frontend noninteractive
+ENV TZ Asia/Kolkata
 
 # Set the working directory to /root
 ENV DIRPATH /root
@@ -18,7 +19,7 @@ RUN apt-get update && apt-get install -y git cmake
 RUN apt-get update && apt-get install -y xvfb
 
 # Install GTSAM
-RUN apt-get update && apt-get install -y libboost-all-dev
+RUN apt-get update && apt-get install -y libboost-all-dev libmetis-dev
 ADD https://api.github.com/repos/borglab/gtsam/git/refs/heads/master version.json
 RUN git clone https://github.com/borglab/gtsam.git
 RUN cd gtsam && \


### PR DESCRIPTION
Seems like metis was a hidden dependency that doesn't break the installation. But gives error when trying to execute the tests. Adding metis to the dockerfile seems to have fixed everything. Not sure if some dependency of metis caused this or metis itself. For now this docker build seems to be stable.

Note:
The requirement for timezone still exists. Adding TZ env did not seem to solve the issue will raise another PR if the fix seems to work.