### PR TITLE
Updating the EurocMono params to give good VIO performance

### DIFF
--- a/params/EurocMono/BackendParams.yaml
+++ b/params/EurocMono/BackendParams.yaml
@@ -18,7 +18,7 @@ initialGyroBiasSigma: 0.01
 #
 # How to linearize the factor:
 # 0: Hessian, 1: Implicit Schur, 2:Jacobian_Q, 3:Jacobian_SVD
-linearizationMode: 0
+linearizationMode: 1
 # How to manage degeneracy
 # 0: Ignore degeneracy, 1: Zero on degeneracy, 2: handle infinity
 degeneracyMode: 1

--- a/params/EurocMono/FrontendParams.yaml
+++ b/params/EurocMono/FrontendParams.yaml
@@ -11,7 +11,7 @@ maxFeatureAge: 25
 # 1: ORB
 # 2: AGAST
 # 3: GFTT, aka Good Features To Track
-feature_detector_type: 3
+feature_detector_type: 0
 maxFeaturesPerFrame: 300
 
 # Good Features To Track specific parameters


### PR DESCRIPTION
**Problem**
On the current version of master, the default EurocMono params give very poor pose estimation. See [this](https://github.com/MIT-SPARK/Kimera-VIO/issues/254) issue for full details. 

**Change Summary**
Updating the EurocMono params to give "good" VIO pose estimation. These changes include:
* Updating `feature_detector_type` field in `params/EurocMono/FrontendParams.yaml` from GFTT to FAST 
* Updating `linearizationMode` field in `params/EurocMono/BackendParams.yaml` from Hessian to Implicit Schur

**Testing**
This change was tested using the `stereoVIOeuroc.bash` script with the Euroc V1_01_easy dataset in a monocular configuration. With the updated params, the VIO performance produced less than +/-0.2m of error in axis. 