### PR TITLE
Updated frontend logger intialisation

### DIFF
--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -413,13 +413,30 @@ FrontendLogger::FrontendLogger()
       output_frontend_img_path_(FLAGS_output_path + "/frontend_images/") {
   namespace fs = std::filesystem;
   const fs::path logger_dir(output_frontend_img_path_);
+  // Create parent directory.
   fs::create_directory(logger_dir);
-  fs::create_directory(logger_dir / "monoFeatureTracksLeftImg");
-  fs::create_directory(logger_dir / "monoTrackingUnrectifiedImg");
-  fs::create_directory(logger_dir / "monoTrackingRectifiedImg");
-  fs::create_directory(logger_dir / "stereoMatchingUnrectifiedImg");
-  fs::create_directory(logger_dir / "stereoMatchingRectifiedImg");
-  fs::create_directory(logger_dir / "rgbdDepthFeaturesImg");
+  // Initialise list of directory names to create
+  std::vector<std::string> sub_directories = {
+    "monoFeatureTracksLeftImg",
+    "monoTrackingUnrectifiedImg",
+    "monoTrackingRectifiedImg",
+    "stereoMatchingUnrectifiedImg",
+    "stereoMatchingRectifiedImg",
+    "rgbdDepthFeaturesImg"
+  };
+  // Loop through the directory names and create each directory if it doesn't exist.
+  for (const auto& sub_directory : sub_directories) {
+    std::string full_sub_dir_path = logger_dir / sub_directory;
+    if(fs::exists(full_sub_dir_path)){
+      // Iterate over the contents of the directory and remove each file.
+      for (const auto& entry : fs::directory_iterator(full_sub_dir_path)) {
+        fs::remove(entry);
+      }
+    }
+    else{
+      fs::create_directory(full_sub_dir_path);
+    }
+  }
 }
 
 void FrontendLogger::logFrontendStats(

--- a/src/logging/Logger.cpp
+++ b/src/logging/Logger.cpp
@@ -413,10 +413,8 @@ FrontendLogger::FrontendLogger()
       output_frontend_img_path_(FLAGS_output_path + "/frontend_images/") {
   namespace fs = std::filesystem;
   const fs::path logger_dir(output_frontend_img_path_);
-  // Create parent directory.
-  fs::create_directory(logger_dir);
-  // Initialise list of directory names to create
-  std::vector<std::string> sub_directories = {
+  fs::create_directory(logger_dir); // Create parent directory.
+  std::vector<std::string> sub_directories = { // Initialise list of directory names to create
     "monoFeatureTracksLeftImg",
     "monoTrackingUnrectifiedImg",
     "monoTrackingRectifiedImg",
@@ -424,16 +422,16 @@ FrontendLogger::FrontendLogger()
     "stereoMatchingRectifiedImg",
     "rgbdDepthFeaturesImg"
   };
+
   // Loop through the directory names and create each directory if it doesn't exist.
   for (const auto& sub_directory : sub_directories) {
     std::string full_sub_dir_path = logger_dir / sub_directory;
-    if(fs::exists(full_sub_dir_path)){
-      // Iterate over the contents of the directory and remove each file.
+    if (fs::exists(full_sub_dir_path)) { // Iterate over the contents of the directory and remove each file.
       for (const auto& entry : fs::directory_iterator(full_sub_dir_path)) {
         fs::remove(entry);
       }
     }
-    else{
+    else {
       fs::create_directory(full_sub_dir_path);
     }
   }


### PR DESCRIPTION
### Outline
This pull request addresses an issue discovered when images are saved for purposes of investigating feature tracking in the frontend.

### Reason for change
This issue occurs when Kimera-VIO is executed consecutively with different datasets—the contents of the directories within /output_logs/frontend_images are not cleared between runs. As a result, images from previous executions can mix with the current execution, leading to misleading results.

The following sub-directories are susceptible to the issue:
- monoFeatureTracksLeftImg
- monoTrackingUnrectifiedImg
- monoTrackingRectifiedImg
- stereoMatchingUnrectifiedImg
- stereoMatchingRectifiedImg
- rgbdDepthFeaturesImg

### Proposed fix
Erase the contents of these directories when upon starting Kimera-VIO to avoid images from consecutive runs from being mixed together.